### PR TITLE
Add CAD drawing fundamentals: line styles, text, layers, dimensions

### DIFF
--- a/src/app/store/editorStore.ts
+++ b/src/app/store/editorStore.ts
@@ -56,6 +56,9 @@ interface EditorState {
   // Layer visibility
   layerVisibility: Record<string, boolean>;
 
+  // Layer lock
+  layerLocked: Record<string, boolean>;
+
   // 3D options
   wireframe: boolean;
   orthographic: boolean;
@@ -73,6 +76,7 @@ interface EditorState {
   setZoom: (zoom: number) => void;
   setCursorWorld: (pos: { x: number; y: number } | null) => void;
   toggleLayerVisibility: (layer: string) => void;
+  setLayerLocked: (layer: string, locked: boolean) => void;
   setWireframe: (on: boolean) => void;
   setOrthographic: (on: boolean) => void;
 }
@@ -95,6 +99,7 @@ export const useEditorStore = create<EditorState>()((set) => ({
   zoom: 0.05,
   cursorWorld: null,
   layerVisibility: { ...defaultLayerVisibility },
+  layerLocked: {},
   wireframe: false,
   orthographic: true,
 
@@ -119,6 +124,13 @@ export const useEditorStore = create<EditorState>()((set) => ({
       layerVisibility: {
         ...state.layerVisibility,
         [layer]: !state.layerVisibility[layer],
+      },
+    })),
+  setLayerLocked: (layer, locked) =>
+    set((state) => ({
+      layerLocked: {
+        ...state.layerLocked,
+        [layer]: locked,
       },
     })),
   setWireframe: (on) => set({ wireframe: on }),

--- a/src/app/store/projectStore.ts
+++ b/src/app/store/projectStore.ts
@@ -42,6 +42,7 @@ export interface ProjectState {
 
   // Dimension operations
   addDimension: (dimension: Dimension) => void;
+  updateDimension: (id: string, updates: Partial<Dimension>) => void;
   deleteDimension: (id: string) => void;
 
   // Opening operations
@@ -286,6 +287,15 @@ export const useProjectStore = create<ProjectState>()(
         set((state) => {
           if (!state.data) return;
           state.data.dimensions.push(dimension);
+          state.isDirty = true;
+        }),
+
+      updateDimension: (id, updates) =>
+        set((state) => {
+          if (!state.data) return;
+          const idx = state.data.dimensions.findIndex((d) => d.id === id);
+          if (idx < 0) return;
+          Object.assign(state.data.dimensions[idx], updates);
           state.isDirty = true;
         }),
 

--- a/src/components/panels/LayerPanel.tsx
+++ b/src/components/panels/LayerPanel.tsx
@@ -14,7 +14,7 @@ const LAYER_LABEL_KEYS: Record<string, keyof Translations> = {
 };
 
 export function LayerPanel() {
-  const { layerVisibility, toggleLayerVisibility } = useEditorStore();
+  const { layerVisibility, toggleLayerVisibility, layerLocked, setLayerLocked } = useEditorStore();
   const { t } = useI18n();
 
   return (
@@ -22,14 +22,30 @@ export function LayerPanel() {
       <div className="panel-header">{t.panelLayers}</div>
       <div className="panel-content">
         {LAYER_NAMES.map((name) => (
-          <label key={name} className="layer-row">
-            <input
-              type="checkbox"
-              checked={layerVisibility[name] !== false}
-              onChange={() => toggleLayerVisibility(name)}
-            />
-            {t[LAYER_LABEL_KEYS[name]] || name}
-          </label>
+          <div key={name} className="layer-row" style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+            <label style={{ display: 'flex', alignItems: 'center', gap: '4px', flex: 1 }}>
+              <input
+                type="checkbox"
+                checked={layerVisibility[name] !== false}
+                onChange={() => toggleLayerVisibility(name)}
+              />
+              {t[LAYER_LABEL_KEYS[name]] || name}
+            </label>
+            <button
+              title={layerLocked[name] ? 'Unlock' : 'Lock'}
+              onClick={() => setLayerLocked(name, !layerLocked[name])}
+              style={{
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                padding: '2px 4px',
+                fontSize: '14px',
+                opacity: layerLocked[name] ? 1 : 0.4,
+              }}
+            >
+              {layerLocked[name] ? '\u{1F512}' : '\u{1F513}'}
+            </button>
+          </div>
         ))}
       </div>
     </div>

--- a/src/components/panels/ObjectTreePanel.tsx
+++ b/src/components/panels/ObjectTreePanel.tsx
@@ -1,9 +1,10 @@
 import { useProjectStore, useEditorStore } from '@/app/store';
 import { useI18n } from '@/i18n';
+import { isLayerLockedForEntity } from '@/domain/rendering/layerLock';
 
 export function ObjectTreePanel() {
   const data = useProjectStore((s) => s.data);
-  const { selectedIds, setSelectedIds, activeStory } = useEditorStore();
+  const { selectedIds, setSelectedIds, activeStory, layerLocked } = useEditorStore();
   const { t } = useI18n();
 
   if (!data) return <div className="panel-content">{t.noProject}</div>;
@@ -32,37 +33,49 @@ export function ObjectTreePanel() {
         {Object.entries(membersByType).map(([type, members]) => (
           <div key={type}>
             <div className="tree-group-label">{typeLabels[type]} ({members.length})</div>
-            {members.map((m) => (
-              <div
-                key={m.id}
-                className={`tree-node ${selectedIds.includes(m.id) ? 'selected' : ''}`}
-                onClick={() => setSelectedIds([m.id])}
-              >
-                {m.id}
-              </div>
-            ))}
+            {members.map((m) => {
+              const locked = isLayerLockedForEntity('member', m.type, layerLocked);
+              return (
+                <div
+                  key={m.id}
+                  className={`tree-node ${selectedIds.includes(m.id) ? 'selected' : ''}`}
+                  style={locked ? { opacity: 0.4, cursor: 'not-allowed' } : undefined}
+                  onClick={() => { if (!locked) setSelectedIds([m.id]); }}
+                >
+                  {m.id}
+                </div>
+              );
+            })}
           </div>
         ))}
         <div className="tree-group-label">{t.memberAnnotation} ({annotations.length})</div>
-        {annotations.map((a) => (
-          <div
-            key={a.id}
-            className={`tree-node ${selectedIds.includes(a.id) ? 'selected' : ''}`}
-            onClick={() => setSelectedIds([a.id])}
-          >
-            {a.id}: {a.text}
-          </div>
-        ))}
+        {annotations.map((a) => {
+          const locked = layerLocked['annotation'];
+          return (
+            <div
+              key={a.id}
+              className={`tree-node ${selectedIds.includes(a.id) ? 'selected' : ''}`}
+              style={locked ? { opacity: 0.4, cursor: 'not-allowed' } : undefined}
+              onClick={() => { if (!locked) setSelectedIds([a.id]); }}
+            >
+              {a.id}: {a.text}
+            </div>
+          );
+        })}
         <div className="tree-group-label">{t.memberDimension} ({dimensions.length})</div>
-        {dimensions.map((d) => (
-          <div
-            key={d.id}
-            className={`tree-node ${selectedIds.includes(d.id) ? 'selected' : ''}`}
-            onClick={() => setSelectedIds([d.id])}
-          >
-            {d.id}
-          </div>
-        ))}
+        {dimensions.map((d) => {
+          const locked = layerLocked['dimension'];
+          return (
+            <div
+              key={d.id}
+              className={`tree-node ${selectedIds.includes(d.id) ? 'selected' : ''}`}
+              style={locked ? { opacity: 0.4, cursor: 'not-allowed' } : undefined}
+              onClick={() => { if (!locked) setSelectedIds([d.id]); }}
+            >
+              {d.id}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/panels/PropertyPanel.tsx
+++ b/src/components/panels/PropertyPanel.tsx
@@ -1,7 +1,10 @@
 import { useProjectStore, useEditorStore } from '@/app/store';
 import { useI18n } from '@/i18n';
-import type { Member, Annotation, Dimension } from '@/domain/structural/types';
+import type { Member, Annotation, Dimension, LineType, TextAlign } from '@/domain/structural/types';
 import { useState, useEffect } from 'react';
+
+const LINE_TYPE_OPTIONS: LineType[] = ['solid', 'dashed', 'dotted', 'chain', 'dashdot'];
+const TEXT_ALIGN_OPTIONS: TextAlign[] = ['left', 'center', 'right'];
 
 export function PropertyPanel() {
   const data = useProjectStore((s) => s.data);
@@ -75,6 +78,27 @@ function MemberProps({ member }: { member: Member }) {
             <CoordRow label="End Y" value={member.end.y} onChange={(v) => updateMember(member.id, { end: { ...member.end, y: v } } as Partial<Member>)} />
           </>
         )}
+        {/* Style properties */}
+        <div className="prop-row">
+          <span className="prop-label">{t.propColor}</span>
+          <input type="color" value={member.color ?? '#000000'} onChange={(e) => updateMember(member.id, { color: e.target.value } as Partial<Member>)} />
+        </div>
+        <CoordRow label={t.propLineWeight} value={member.lineWeight ?? 20} onChange={(v) => updateMember(member.id, { lineWeight: v } as Partial<Member>)} />
+        <div className="prop-row">
+          <span className="prop-label">{t.propLineType}</span>
+          <select className="prop-select" value={member.lineType ?? 'solid'} onChange={(e) => updateMember(member.id, { lineType: e.target.value as LineType } as Partial<Member>)}>
+            {LINE_TYPE_OPTIONS.map((lt) => <option key={lt} value={lt}>{lt}</option>)}
+          </select>
+        </div>
+        {member.type === 'slab' && (
+          <>
+            <div className="prop-row">
+              <span className="prop-label">{t.propFillColor}</span>
+              <input type="color" value={member.fillColor ?? '#9b59b6'} onChange={(e) => updateMember(member.id, { fillColor: e.target.value } as Partial<Member>)} />
+            </div>
+            <CoordRow label={t.propFillOpacity} value={member.fillOpacity ?? 0.1} onChange={(v) => updateMember(member.id, { fillOpacity: Math.max(0, Math.min(1, v)) } as Partial<Member>)} />
+          </>
+        )}
       </div>
     </div>
   );
@@ -91,16 +115,34 @@ function AnnotationProps({ annotation }: { annotation: Annotation }) {
         <div className="prop-row"><span className="prop-label">{t.propId}</span><span>{annotation.id}</span></div>
         <div className="prop-row">
           <span className="prop-label">{t.propText}</span>
-          <input className="prop-input" value={annotation.text} onChange={(e) => updateAnnotation(annotation.id, { text: e.target.value })} />
+          <textarea
+            className="prop-input"
+            value={annotation.text}
+            onChange={(e) => updateAnnotation(annotation.id, { text: e.target.value })}
+            rows={3}
+            style={{ resize: 'vertical', fontFamily: 'inherit', fontSize: 'inherit' }}
+          />
         </div>
         <CoordRow label="X" value={annotation.x} onChange={(v) => updateAnnotation(annotation.id, { x: v })} />
         <CoordRow label="Y" value={annotation.y} onChange={(v) => updateAnnotation(annotation.id, { y: v })} />
+        <div className="prop-row">
+          <span className="prop-label">{t.propColor}</span>
+          <input type="color" value={annotation.color ?? '#000000'} onChange={(e) => updateAnnotation(annotation.id, { color: e.target.value })} />
+        </div>
+        <div className="prop-row">
+          <span className="prop-label">{t.propTextAlign}</span>
+          <select className="prop-select" value={annotation.textAlign ?? 'left'} onChange={(e) => updateAnnotation(annotation.id, { textAlign: e.target.value as TextAlign })}>
+            {TEXT_ALIGN_OPTIONS.map((ta) => <option key={ta} value={ta}>{ta}</option>)}
+          </select>
+        </div>
+        <CoordRow label={t.propRotation} value={annotation.rotation ?? 0} onChange={(v) => updateAnnotation(annotation.id, { rotation: v })} />
       </div>
     </div>
   );
 }
 
 function DimensionProps({ dimension }: { dimension: Dimension }) {
+  const updateDimension = useProjectStore((s) => s.updateDimension);
   const { t } = useI18n();
 
   return (
@@ -112,7 +154,18 @@ function DimensionProps({ dimension }: { dimension: Dimension }) {
           <span className="prop-label">{t.propLength}</span>
           <span>{Math.sqrt((dimension.end.x - dimension.start.x) ** 2 + (dimension.end.y - dimension.start.y) ** 2).toFixed(0)} mm</span>
         </div>
-        <div className="prop-row"><span className="prop-label">{t.propOffset}</span><span>{dimension.offset}</span></div>
+        <CoordRow label={t.propOffset} value={dimension.offset} onChange={(v) => updateDimension(dimension.id, { offset: v })} />
+        <div className="prop-row">
+          <span className="prop-label">{t.propColor}</span>
+          <input type="color" value={dimension.color ?? '#000000'} onChange={(e) => updateDimension(dimension.id, { color: e.target.value })} />
+        </div>
+        <CoordRow label={t.propLineWeight} value={dimension.lineWeight ?? 15} onChange={(v) => updateDimension(dimension.id, { lineWeight: v })} />
+        <div className="prop-row">
+          <span className="prop-label">{t.propLineType}</span>
+          <select className="prop-select" value={dimension.lineType ?? 'solid'} onChange={(e) => updateDimension(dimension.id, { lineType: e.target.value as LineType })}>
+            {LINE_TYPE_OPTIONS.map((lt) => <option key={lt} value={lt}>{lt}</option>)}
+          </select>
+        </div>
       </div>
     </div>
   );

--- a/src/domain/export/dxfExport.ts
+++ b/src/domain/export/dxfExport.ts
@@ -82,7 +82,11 @@ export function exportDxf(data: ProjectData, storyId: string): string {
   // Annotations
   const annotations = data.annotations.filter((a) => a.story === storyId);
   for (const a of annotations) {
-    addText(lines, 'ANNOTATION', a.x, a.y, a.fontSize ?? 250, a.text, a.rotation);
+    if (a.text.includes('\n')) {
+      addMText(lines, 'ANNOTATION', a.x, a.y, a.fontSize ?? 250, a.text, a.rotation);
+    } else {
+      addText(lines, 'ANNOTATION', a.x, a.y, a.fontSize ?? 250, a.text, a.rotation);
+    }
   }
 
   lines.push('0', 'ENDSEC');
@@ -170,6 +174,7 @@ function addLwPolyline(lines: string[], layer: string, points: number[][], close
 }
 
 function addText(lines: string[], layer: string, x: number, y: number, height: number, text: string, rotation?: number) {
+  const sanitized = text.replace(/\r?\n/g, ' ');
   lines.push('0', 'TEXT');
   lines.push('8', layer);
   lines.push('10', String(x), '20', String(y), '30', '0');
@@ -177,5 +182,17 @@ function addText(lines: string[], layer: string, x: number, y: number, height: n
   if (rotation) {
     lines.push('50', String(rotation));
   }
-  lines.push('1', text);
+  lines.push('1', sanitized);
+}
+
+function addMText(lines: string[], layer: string, x: number, y: number, height: number, text: string, rotation?: number) {
+  lines.push('0', 'MTEXT');
+  lines.push('8', layer);
+  lines.push('10', String(x), '20', String(y), '30', '0');
+  lines.push('40', String(height));
+  if (rotation) {
+    lines.push('50', String(rotation));
+  }
+  const encoded = text.replace(/\r?\n/g, '\\P');
+  lines.push('1', encoded);
 }

--- a/src/domain/export/dxfExport.ts
+++ b/src/domain/export/dxfExport.ts
@@ -82,7 +82,7 @@ export function exportDxf(data: ProjectData, storyId: string): string {
   // Annotations
   const annotations = data.annotations.filter((a) => a.story === storyId);
   for (const a of annotations) {
-    addText(lines, 'ANNOTATION', a.x, a.y, a.fontSize ?? 250, a.text);
+    addText(lines, 'ANNOTATION', a.x, a.y, a.fontSize ?? 250, a.text, a.rotation);
   }
 
   lines.push('0', 'ENDSEC');
@@ -169,10 +169,13 @@ function addLwPolyline(lines: string[], layer: string, points: number[][], close
   }
 }
 
-function addText(lines: string[], layer: string, x: number, y: number, height: number, text: string) {
+function addText(lines: string[], layer: string, x: number, y: number, height: number, text: string, rotation?: number) {
   lines.push('0', 'TEXT');
   lines.push('8', layer);
   lines.push('10', String(x), '20', String(y), '30', '0');
   lines.push('40', String(height));
+  if (rotation) {
+    lines.push('50', String(rotation));
+  }
   lines.push('1', text);
 }

--- a/src/domain/export/svgExport.ts
+++ b/src/domain/export/svgExport.ts
@@ -1,5 +1,6 @@
-import type { ProjectData, Member, Section, Sheet, TitleBlockTemplate } from '@/domain/structural/types';
+import type { ProjectData, Member, Section, Sheet, TitleBlockTemplate, TextAlign } from '@/domain/structural/types';
 import { sub2D, normalize2D, perpendicular2D, distance2D } from '@/domain/geometry/point';
+import { lineTypeToDashArray } from '@/domain/rendering/lineStyle';
 
 const PAPER_SIZES: Record<string, { width: number; height: number }> = {
   A0: { width: 1189, height: 841 },
@@ -8,6 +9,14 @@ const PAPER_SIZES: Record<string, { width: number; height: number }> = {
   A3: { width: 420, height: 297 },
   A4: { width: 297, height: 210 },
 };
+
+function textAlignToAnchor(align: TextAlign | undefined): string {
+  switch (align) {
+    case 'center': return 'middle';
+    case 'right': return 'end';
+    default: return 'start';
+  }
+}
 
 export function exportSvg(data: ProjectData, sheetId: string): string {
   const sheet = data.sheets.find((s) => s.id === sheetId);
@@ -74,7 +83,23 @@ export function exportSvg(data: ProjectData, sheetId: string): string {
   // Annotations
   for (const a of annotations) {
     const fs = a.fontSize ?? 300;
-    svgLines.push(`  <text class="layer-annotation" x="${a.x}" y="${a.y}" font-size="${fs}" fill="#34495e" transform="translate(0,0) scale(1,-1) translate(0,${-2 * a.y})">${escapeXml(a.text)}</text>`);
+    const fillColor = a.color ?? '#34495e';
+    const anchor = textAlignToAnchor(a.textAlign);
+    const rotation = a.rotation ?? 0;
+    const rotateAttr = rotation !== 0 ? ` rotate(${-rotation}, ${a.x}, ${-a.y})` : '';
+    const transform = `translate(0,0) scale(1,-1) translate(0,${-2 * a.y})${rotateAttr}`;
+    const lines = a.text.split('\n');
+
+    if (lines.length <= 1) {
+      svgLines.push(`  <text class="layer-annotation" x="${a.x}" y="${a.y}" font-size="${fs}" fill="${escapeXml(fillColor)}" text-anchor="${anchor}" transform="${transform}">${escapeXml(a.text)}</text>`);
+    } else {
+      svgLines.push(`  <text class="layer-annotation" x="${a.x}" y="${a.y}" font-size="${fs}" fill="${escapeXml(fillColor)}" text-anchor="${anchor}" transform="${transform}">`);
+      for (let i = 0; i < lines.length; i++) {
+        const dy = i === 0 ? 0 : fs * 1.2;
+        svgLines.push(`    <tspan x="${a.x}" dy="${dy}">${escapeXml(lines[i])}</tspan>`);
+      }
+      svgLines.push(`  </text>`);
+    }
   }
 
   svgLines.push(`</g>`);
@@ -85,12 +110,16 @@ export function exportSvg(data: ProjectData, sheetId: string): string {
 
 function renderMemberSvg(m: Member, sections: Section[]): string {
   const sec = sections.find((s) => s.id === m.sectionId);
+  const lw = m.lineWeight ?? 20;
+  const dash = lineTypeToDashArray(m.lineType);
+  const dashAttr = dash ? ` stroke-dasharray="${dash}"` : '';
 
   switch (m.type) {
     case 'column': {
       const w = sec && 'width' in sec ? sec.width : 600;
       const d = sec && 'depth' in sec ? sec.depth : 600;
-      return `  <rect class="layer-member-column" x="${m.start.x - w / 2}" y="${m.start.y - d / 2}" width="${w}" height="${d}" fill="rgba(231,76,60,0.3)" stroke="#e74c3c" stroke-width="20"/>`;
+      const strokeColor = m.color ?? '#e74c3c';
+      return `  <rect class="layer-member-column" x="${m.start.x - w / 2}" y="${m.start.y - d / 2}" width="${w}" height="${d}" fill="rgba(231,76,60,0.3)" stroke="${strokeColor}" stroke-width="${lw}"${dashAttr}/>`;
     }
     case 'beam': {
       const w = sec && 'width' in sec ? sec.width : 300;
@@ -101,7 +130,8 @@ function renderMemberSvg(m: Member, sections: Section[]): string {
       const nx = (-dy / len) * (w / 2);
       const ny = (dx / len) * (w / 2);
       const pts = `${m.start.x + nx},${m.start.y + ny} ${m.end.x + nx},${m.end.y + ny} ${m.end.x - nx},${m.end.y - ny} ${m.start.x - nx},${m.start.y - ny}`;
-      return `  <polygon class="layer-member-beam" points="${pts}" fill="rgba(243,156,18,0.2)" stroke="#f39c12" stroke-width="20"/>`;
+      const strokeColor = m.color ?? '#f39c12';
+      return `  <polygon class="layer-member-beam" points="${pts}" fill="rgba(243,156,18,0.2)" stroke="${strokeColor}" stroke-width="${lw}"${dashAttr}/>`;
     }
     case 'wall': {
       const t = sec && 'thickness' in sec ? sec.thickness : m.thickness;
@@ -112,16 +142,21 @@ function renderMemberSvg(m: Member, sections: Section[]): string {
       const nx = (-dy / len) * (t / 2);
       const ny = (dx / len) * (t / 2);
       const pts = `${m.start.x + nx},${m.start.y + ny} ${m.end.x + nx},${m.end.y + ny} ${m.end.x - nx},${m.end.y - ny} ${m.start.x - nx},${m.start.y - ny}`;
-      return `  <polygon class="layer-member-wall" points="${pts}" fill="rgba(0,188,212,0.2)" stroke="#00bcd4" stroke-width="20"/>`;
+      const strokeColor = m.color ?? '#00bcd4';
+      return `  <polygon class="layer-member-wall" points="${pts}" fill="rgba(0,188,212,0.2)" stroke="${strokeColor}" stroke-width="${lw}"${dashAttr}/>`;
     }
     case 'slab': {
       const pts = m.polygon.map((p) => `${p.x},${p.y}`).join(' ');
-      return `  <polygon class="layer-member-slab" points="${pts}" fill="rgba(155,89,182,0.1)" stroke="#9b59b6" stroke-width="20" stroke-dasharray="200 100"/>`;
+      const strokeColor = m.color ?? '#9b59b6';
+      const slabDash = dash ?? '200 100';
+      const fillColor = m.fillColor ?? 'rgba(155,89,182,0.1)';
+      const opacityAttr = m.fillOpacity !== undefined ? ` fill-opacity="${m.fillOpacity}"` : '';
+      return `  <polygon class="layer-member-slab" points="${pts}" fill="${fillColor}"${opacityAttr} stroke="${strokeColor}" stroke-width="${lw}" stroke-dasharray="${slabDash}"/>`;
     }
   }
 }
 
-function renderDimensionSvg(d: { start: { x: number; y: number }; end: { x: number; y: number }; offset: number; text?: string }): string {
+function renderDimensionSvg(d: { start: { x: number; y: number }; end: { x: number; y: number }; offset: number; text?: string; color?: string; lineWeight?: number; lineType?: import('@/domain/structural/types').LineType }): string {
   const dir = normalize2D(sub2D(d.end, d.start));
   const perp = perpendicular2D(dir);
   const s = { x: d.start.x + perp.x * d.offset, y: d.start.y + perp.y * d.offset };
@@ -129,13 +164,24 @@ function renderDimensionSvg(d: { start: { x: number; y: number }; end: { x: numb
   const length = distance2D(d.start, d.end);
   const text = d.text ?? length.toFixed(0);
   const mid = { x: (s.x + e.x) / 2, y: (s.y + e.y) / 2 };
+  const color = d.color ?? '#7f8c8d';
+  const lw = d.lineWeight ?? 15;
+  const dash = lineTypeToDashArray(d.lineType);
+  const dashAttr = dash ? ` stroke-dasharray="${dash}"` : '';
+
+  const textSize = 250;
+  const arrowLen = textSize * 0.4;
+  const arrowHalf = arrowLen * 0.35;
+
+  const startArrow = `${s.x},${s.y} ${s.x + dir.x * arrowLen + perp.x * arrowHalf},${s.y + dir.y * arrowLen + perp.y * arrowHalf} ${s.x + dir.x * arrowLen - perp.x * arrowHalf},${s.y + dir.y * arrowLen - perp.y * arrowHalf}`;
+  const endArrow = `${e.x},${e.y} ${e.x - dir.x * arrowLen + perp.x * arrowHalf},${e.y - dir.y * arrowLen + perp.y * arrowHalf} ${e.x - dir.x * arrowLen - perp.x * arrowHalf},${e.y - dir.y * arrowLen - perp.y * arrowHalf}`;
 
   return [
     `  <g class="layer-dimension">`,
-    `    <line x1="${s.x}" y1="${s.y}" x2="${e.x}" y2="${e.y}" stroke="#7f8c8d" stroke-width="15"/>`,
-    `    <circle cx="${s.x}" cy="${s.y}" r="50" fill="#7f8c8d"/>`,
-    `    <circle cx="${e.x}" cy="${e.y}" r="50" fill="#7f8c8d"/>`,
-    `    <text x="${mid.x}" y="${mid.y}" text-anchor="middle" dominant-baseline="central" font-size="250" fill="#7f8c8d" transform="translate(0,0) scale(1,-1) translate(0,${-2 * mid.y})">${text}</text>`,
+    `    <line x1="${s.x}" y1="${s.y}" x2="${e.x}" y2="${e.y}" stroke="${color}" stroke-width="${lw}"${dashAttr}/>`,
+    `    <polygon points="${startArrow}" fill="${color}"/>`,
+    `    <polygon points="${endArrow}" fill="${color}"/>`,
+    `    <text x="${mid.x}" y="${mid.y}" text-anchor="middle" dominant-baseline="central" font-size="${textSize}" fill="${color}" transform="translate(0,0) scale(1,-1) translate(0,${-2 * mid.y})">${text}</text>`,
     `  </g>`,
   ].join('\n');
 }

--- a/src/domain/rendering/layerLock.ts
+++ b/src/domain/rendering/layerLock.ts
@@ -1,0 +1,22 @@
+/**
+ * Determine if an entity's layer is locked.
+ */
+export function isLayerLockedForEntity(
+  entityKind: 'member' | 'annotation' | 'dimension',
+  memberType: string | undefined,
+  layerLocked: Record<string, boolean>,
+): boolean {
+  if (entityKind === 'annotation') return !!layerLocked['annotation'];
+  if (entityKind === 'dimension') return !!layerLocked['dimension'];
+  if (entityKind === 'member' && memberType) {
+    return !!layerLocked[`member-${memberType}`];
+  }
+  return false;
+}
+
+/**
+ * Get layer name for a member type.
+ */
+export function memberTypeToLayerName(memberType: string): string {
+  return `member-${memberType}`;
+}

--- a/src/domain/rendering/lineStyle.ts
+++ b/src/domain/rendering/lineStyle.ts
@@ -1,0 +1,17 @@
+import type { LineType } from '@/domain/structural/types';
+
+export function lineTypeToDashArray(lineType: LineType | undefined, scale = 1): string | undefined {
+  const s = scale;
+  switch (lineType) {
+    case 'dashed':
+      return `${200 * s} ${100 * s}`;
+    case 'dotted':
+      return `${20 * s} ${80 * s}`;
+    case 'chain':
+      return `${300 * s} ${80 * s} ${20 * s} ${80 * s}`;
+    case 'dashdot':
+      return `${200 * s} ${80 * s} ${20 * s} ${80 * s}`;
+    default:
+      return undefined;
+  }
+}

--- a/src/domain/structural/types.ts
+++ b/src/domain/structural/types.ts
@@ -1,5 +1,10 @@
 import type { Point2D, Point3D } from '@/domain/geometry/types';
 
+// ── Drawing style types ─────────────────────────────────────
+
+export type LineType = 'solid' | 'dashed' | 'dotted' | 'chain' | 'dashdot';
+export type TextAlign = 'left' | 'center' | 'right';
+
 // ── Project Root ─────────────────────────────────────────────
 
 export interface ProjectData {
@@ -89,6 +94,9 @@ interface MemberBase {
   materialId: string;
   rotation?: number;
   tags?: string[];
+  color?: string;
+  lineWeight?: number;
+  lineType?: LineType;
 }
 
 export interface ColumnMember extends MemberBase {
@@ -115,6 +123,8 @@ export interface SlabMember extends MemberBase {
   type: 'slab';
   polygon: Point2D[];
   level: number;
+  fillColor?: string;
+  fillOpacity?: number;
 }
 
 export type Member = ColumnMember | BeamMember | WallMember | SlabMember;
@@ -143,6 +153,8 @@ export interface Annotation {
   text: string;
   fontSize?: number;
   rotation?: number;
+  color?: string;
+  textAlign?: TextAlign;
 }
 
 // ── Dimension ────────────────────────────────────────────────
@@ -154,6 +166,9 @@ export interface Dimension {
   end: Point2D;
   offset: number;
   text?: string;
+  color?: string;
+  lineWeight?: number;
+  lineType?: LineType;
 }
 
 // ── View ─────────────────────────────────────────────────────

--- a/src/features/editor2d/layers/AnnotationLayer.tsx
+++ b/src/features/editor2d/layers/AnnotationLayer.tsx
@@ -1,8 +1,16 @@
-import type { Annotation } from '@/domain/structural/types';
+import type { Annotation, TextAlign } from '@/domain/structural/types';
 
 interface Props {
   annotations: Annotation[];
   selectedIds: string[];
+}
+
+function textAlignToAnchor(align: TextAlign | undefined): 'start' | 'middle' | 'end' {
+  switch (align) {
+    case 'center': return 'middle';
+    case 'right': return 'end';
+    default: return 'start';
+  }
 }
 
 export function AnnotationLayer({ annotations, selectedIds }: Props) {
@@ -10,8 +18,16 @@ export function AnnotationLayer({ annotations, selectedIds }: Props) {
     <g className="layer-annotation">
       {annotations.map((a) => {
         const selected = selectedIds.includes(a.id);
-        const color = selected ? 'var(--color-selection)' : 'var(--color-annotation)';
+        const color = selected ? 'var(--color-selection)' : (a.color ?? 'var(--color-annotation)');
         const fontSize = a.fontSize ?? 300;
+        const anchor = textAlignToAnchor(a.textAlign);
+        const rotation = a.rotation ?? 0;
+        const lines = a.text.split('\n');
+
+        // Build transform: flip Y for text readability, then apply rotation
+        const baseTransform = `translate(0,0) scale(1,-1) translate(0,${-2 * a.y})`;
+        const rotateTransform = rotation !== 0 ? ` rotate(${-rotation}, ${a.x}, ${-a.y})` : '';
+        const transform = baseTransform + rotateTransform;
 
         return (
           <text
@@ -22,10 +38,19 @@ export function AnnotationLayer({ annotations, selectedIds }: Props) {
             fontSize={fontSize}
             fill={color}
             fontWeight={selected ? 'bold' : 'normal'}
-            transform={`translate(0,0) scale(1,-1) translate(0,${-2 * a.y})`}
+            textAnchor={anchor}
+            transform={transform}
             style={{ cursor: 'pointer' }}
           >
-            {a.text}
+            {lines.length <= 1 ? (
+              a.text
+            ) : (
+              lines.map((line, i) => (
+                <tspan key={i} x={a.x} dy={i === 0 ? 0 : fontSize * 1.2}>
+                  {line}
+                </tspan>
+              ))
+            )}
           </text>
         );
       })}

--- a/src/features/editor2d/layers/DimensionLayer.tsx
+++ b/src/features/editor2d/layers/DimensionLayer.tsx
@@ -1,5 +1,6 @@
 import type { Dimension } from '@/domain/structural/types';
 import { sub2D, normalize2D, perpendicular2D, distance2D } from '@/domain/geometry/point';
+import { lineTypeToDashArray } from '@/domain/rendering/lineStyle';
 
 interface Props {
   dimensions: Dimension[];
@@ -36,26 +37,47 @@ function DimensionShape({ dim, selected }: { dim: Dimension; selected: boolean }
   const text = dim.text ?? length.toFixed(0);
 
   const mid = { x: (s.x + e.x) / 2, y: (s.y + e.y) / 2 };
-  const color = selected ? 'var(--color-selection)' : 'var(--color-dimension)';
-  const sw = selected ? 30 : 15;
+  const baseLw = dim.lineWeight ?? 15;
+  const color = selected ? 'var(--color-selection)' : (dim.color ?? 'var(--color-dimension)');
+  const sw = selected ? baseLw * 2 : baseLw;
+  const dash = lineTypeToDashArray(dim.lineType);
+  const textSize = 250;
+
+  // Arrow triangle size based on text size
+  const arrowLen = textSize * 0.4;
+  const arrowHalf = arrowLen * 0.35;
+
+  // Arrow at start: pointing inward toward end
+  const startArrow = [
+    `${s.x},${s.y}`,
+    `${s.x + dir.x * arrowLen + perp.x * arrowHalf},${s.y + dir.y * arrowLen + perp.y * arrowHalf}`,
+    `${s.x + dir.x * arrowLen - perp.x * arrowHalf},${s.y + dir.y * arrowLen - perp.y * arrowHalf}`,
+  ].join(' ');
+
+  // Arrow at end: pointing inward toward start
+  const endArrow = [
+    `${e.x},${e.y}`,
+    `${e.x - dir.x * arrowLen + perp.x * arrowHalf},${e.y - dir.y * arrowLen + perp.y * arrowHalf}`,
+    `${e.x - dir.x * arrowLen - perp.x * arrowHalf},${e.y - dir.y * arrowLen - perp.y * arrowHalf}`,
+  ].join(' ');
 
   return (
     <g data-id={dim.id} style={{ cursor: 'pointer' }}>
       {/* Dimension line */}
-      <line x1={s.x} y1={s.y} x2={e.x} y2={e.y} stroke={color} strokeWidth={sw} />
+      <line x1={s.x} y1={s.y} x2={e.x} y2={e.y} stroke={color} strokeWidth={sw} strokeDasharray={dash} />
       {/* Extension lines */}
       <line x1={s1.x} y1={s1.y} x2={s2.x} y2={s2.y} stroke={color} strokeWidth={sw * 0.7} />
       <line x1={e1.x} y1={e1.y} x2={e2.x} y2={e2.y} stroke={color} strokeWidth={sw * 0.7} />
-      {/* Arrows */}
-      <circle cx={s.x} cy={s.y} r={50} fill={color} />
-      <circle cx={e.x} cy={e.y} r={50} fill={color} />
+      {/* Arrow triangles */}
+      <polygon points={startArrow} fill={color} />
+      <polygon points={endArrow} fill={color} />
       {/* Text */}
       <text
         x={mid.x}
         y={mid.y}
         textAnchor="middle"
         dominantBaseline="central"
-        fontSize={250}
+        fontSize={textSize}
         fill={color}
         transform={`translate(0,0) scale(1,-1) translate(0,${-2 * mid.y})`}
       >

--- a/src/features/editor2d/layers/MemberLayer.tsx
+++ b/src/features/editor2d/layers/MemberLayer.tsx
@@ -1,4 +1,5 @@
 import type { Member, Section } from '@/domain/structural/types';
+import { lineTypeToDashArray } from '@/domain/rendering/lineStyle';
 
 interface Props {
   members: Member[];
@@ -88,6 +89,10 @@ function ColumnShape({
   const cy = member.start.y;
   const hw = width / 2;
   const hd = depth / 2;
+  const lw = member.lineWeight ?? 20;
+  const sw = selected ? lw * 2 : lw;
+  const strokeColor = selected ? 'var(--color-selection)' : (member.color ?? 'var(--color-column)');
+  const dash = lineTypeToDashArray(member.lineType);
 
   return (
     <rect
@@ -97,8 +102,9 @@ function ColumnShape({
       width={width}
       height={depth}
       fill={selected ? 'rgba(59,130,246,0.3)' : 'rgba(231,76,60,0.3)'}
-      stroke={selected ? 'var(--color-selection)' : 'var(--color-column)'}
-      strokeWidth={selected ? 40 : 20}
+      stroke={strokeColor}
+      strokeWidth={sw}
+      strokeDasharray={dash}
       style={{ cursor: 'pointer' }}
     />
   );
@@ -128,13 +134,19 @@ function BeamShape({
     `${start.x - nx},${start.y - ny}`,
   ].join(' ');
 
+  const lw = member.lineWeight ?? 20;
+  const sw = selected ? lw * 2 : lw;
+  const strokeColor = selected ? 'var(--color-selection)' : (member.color ?? 'var(--color-beam)');
+  const dash = lineTypeToDashArray(member.lineType);
+
   return (
     <polygon
       data-id={member.id}
       points={points}
       fill={selected ? 'rgba(59,130,246,0.2)' : 'rgba(243,156,18,0.2)'}
-      stroke={selected ? 'var(--color-selection)' : 'var(--color-beam)'}
-      strokeWidth={selected ? 40 : 20}
+      stroke={strokeColor}
+      strokeWidth={sw}
+      strokeDasharray={dash}
       style={{ cursor: 'pointer' }}
     />
   );
@@ -164,13 +176,19 @@ function WallShape({
     `${start.x - nx},${start.y - ny}`,
   ].join(' ');
 
+  const lw = member.lineWeight ?? 20;
+  const sw = selected ? lw * 2 : lw;
+  const strokeColor = selected ? 'var(--color-selection)' : (member.color ?? 'var(--color-wall)');
+  const dash = lineTypeToDashArray(member.lineType);
+
   return (
     <polygon
       data-id={member.id}
       points={points}
       fill={selected ? 'rgba(59,130,246,0.2)' : 'rgba(0,188,212,0.2)'}
-      stroke={selected ? 'var(--color-selection)' : 'var(--color-wall)'}
-      strokeWidth={selected ? 40 : 20}
+      stroke={strokeColor}
+      strokeWidth={sw}
+      strokeDasharray={dash}
       style={{ cursor: 'pointer' }}
     />
   );
@@ -184,15 +202,24 @@ function SlabShape({
   selected: boolean;
 }) {
   const points = member.polygon.map((p) => `${p.x},${p.y}`).join(' ');
+  const lw = member.lineWeight ?? 20;
+  const sw = selected ? lw * 2 : lw;
+  const strokeColor = selected ? 'var(--color-selection)' : (member.color ?? 'var(--color-slab)');
+  const dash = lineTypeToDashArray(member.lineType) ?? '200 100';
+  const fillColor = selected
+    ? 'rgba(59,130,246,0.15)'
+    : (member.fillColor ?? 'rgba(155,89,182,0.1)');
+  const fillOpacity = member.fillOpacity ?? undefined;
 
   return (
     <polygon
       data-id={member.id}
       points={points}
-      fill={selected ? 'rgba(59,130,246,0.15)' : 'rgba(155,89,182,0.1)'}
-      stroke={selected ? 'var(--color-selection)' : 'var(--color-slab)'}
-      strokeWidth={selected ? 40 : 20}
-      strokeDasharray="200 100"
+      fill={fillColor}
+      fillOpacity={fillOpacity}
+      stroke={strokeColor}
+      strokeWidth={sw}
+      strokeDasharray={dash}
       style={{ cursor: 'pointer' }}
     />
   );

--- a/src/features/editor2d/useEditorInteraction.ts
+++ b/src/features/editor2d/useEditorInteraction.ts
@@ -198,7 +198,7 @@ export function useEditorInteraction() {
 
   const handleClick = useCallback(
     (worldPos: Point2D, e: React.MouseEvent) => {
-      const { activeTool, setSelectedIds, toggleSelection } = useEditorStore.getState();
+      const { activeTool, setSelectedIds, toggleSelection, layerLocked } = useEditorStore.getState();
 
       if (activeTool === 'select') {
         const target = (e.target as SVGElement).closest('[data-id]');
@@ -207,6 +207,18 @@ export function useEditorInteraction() {
           return;
         }
         const id = target.getAttribute('data-id')!;
+
+        // Check if entity's layer is locked
+        const data = useProjectStore.getState().data;
+        if (data) {
+          const member = data.members.find((m) => m.id === id);
+          if (member && layerLocked[`member-${member.type}`]) return;
+          const annotation = data.annotations.find((a) => a.id === id);
+          if (annotation && layerLocked['annotation']) return;
+          const dimension = data.dimensions.find((d) => d.id === id);
+          if (dimension && layerLocked['dimension']) return;
+        }
+
         if (e.shiftKey || e.ctrlKey || e.metaKey) {
           toggleSelection(id);
         } else {

--- a/src/features/viewer3d/MemberMesh.tsx
+++ b/src/features/viewer3d/MemberMesh.tsx
@@ -43,7 +43,7 @@ export function MemberMesh({
 
   if (!geometry) return null;
 
-  const color = selected ? COLORS.selected : COLORS[member.type];
+  const color = selected ? COLORS.selected : (member.color ?? COLORS[member.type]);
   const materialProps = getMaterialProps(member.type, color, wireframe, clippingPlanes);
 
   return (

--- a/src/features/viewer3d/Viewer3D.tsx
+++ b/src/features/viewer3d/Viewer3D.tsx
@@ -387,19 +387,23 @@ export function Viewer3D() {
               </mesh>
             )}
 
-            {filteredMembers.map((member) => (
-              <MemberMesh
-                key={member.id}
-                member={member}
-                section={sectionMap.get(member.sectionId)}
-                openings={openingsMap.get(member.id) ?? []}
-                selected={selectedIds.includes(member.id)}
-                wireframe={wireframe}
-                engine={geometryEngine}
-                clippingPlanes={clippingPlanes}
-                onClick={() => setSelectedIds([member.id])}
-              />
-            ))}
+            {filteredMembers.map((member) => {
+              const layerLocked = useEditorStore.getState().layerLocked;
+              const locked = !!layerLocked[`member-${member.type}`];
+              return (
+                <MemberMesh
+                  key={member.id}
+                  member={member}
+                  section={sectionMap.get(member.sectionId)}
+                  openings={openingsMap.get(member.id) ?? []}
+                  selected={selectedIds.includes(member.id)}
+                  wireframe={wireframe}
+                  engine={geometryEngine}
+                  clippingPlanes={clippingPlanes}
+                  onClick={() => { if (!locked) setSelectedIds([member.id]); }}
+                />
+              );
+            })}
           </group>
         </group>
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -55,6 +55,13 @@ export const en: Translations = {
   propText: 'Text',
   propLength: 'Length',
   propOffset: 'Offset',
+  propColor: 'Color',
+  propLineWeight: 'Line Weight',
+  propLineType: 'Line Type',
+  propTextAlign: 'Align',
+  propFillColor: 'Fill Color',
+  propFillOpacity: 'Fill Opacity',
+  propRotation: 'Rotation',
 
   statusZoom: 'Zoom',
   statusSnap: 'Snap',

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -55,6 +55,13 @@ export const ja: Translations = {
   propText: 'テキスト',
   propLength: '長さ',
   propOffset: 'オフセット',
+  propColor: '色',
+  propLineWeight: '線幅',
+  propLineType: '線種',
+  propTextAlign: '配置',
+  propFillColor: '塗り色',
+  propFillOpacity: '塗り透過',
+  propRotation: '回転',
 
   statusZoom: 'ズーム',
   statusSnap: 'スナップ',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -64,6 +64,13 @@ export interface Translations {
   propText: string;
   propLength: string;
   propOffset: string;
+  propColor: string;
+  propLineWeight: string;
+  propLineType: string;
+  propTextAlign: string;
+  propFillColor: string;
+  propFillOpacity: string;
+  propRotation: string;
 
   // Status bar
   statusZoom: string;

--- a/src/schemas/project.schema.json
+++ b/src/schemas/project.schema.json
@@ -70,6 +70,14 @@
     }
   },
   "$defs": {
+    "LineType": {
+      "type": "string",
+      "enum": ["solid", "dashed", "dotted", "chain", "dashdot"]
+    },
+    "TextAlign": {
+      "type": "string",
+      "enum": ["left", "center", "right"]
+    },
     "Point2D": {
       "type": "object",
       "required": ["x", "y"],
@@ -205,7 +213,10 @@
         "start": { "$ref": "#/$defs/Point3D" },
         "end": { "$ref": "#/$defs/Point3D" },
         "rotation": { "type": "number" },
-        "tags": { "type": "array", "items": { "type": "string" } }
+        "tags": { "type": "array", "items": { "type": "string" } },
+        "color": { "type": "string" },
+        "lineWeight": { "type": "number", "exclusiveMinimum": 0 },
+        "lineType": { "$ref": "#/$defs/LineType" }
       }
     },
     "BeamMember": {
@@ -221,7 +232,10 @@
         "start": { "$ref": "#/$defs/Point3D" },
         "end": { "$ref": "#/$defs/Point3D" },
         "rotation": { "type": "number" },
-        "tags": { "type": "array", "items": { "type": "string" } }
+        "tags": { "type": "array", "items": { "type": "string" } },
+        "color": { "type": "string" },
+        "lineWeight": { "type": "number", "exclusiveMinimum": 0 },
+        "lineType": { "$ref": "#/$defs/LineType" }
       }
     },
     "WallMember": {
@@ -242,7 +256,10 @@
         "height": { "type": "number", "exclusiveMinimum": 0 },
         "thickness": { "type": "number", "exclusiveMinimum": 0 },
         "rotation": { "type": "number" },
-        "tags": { "type": "array", "items": { "type": "string" } }
+        "tags": { "type": "array", "items": { "type": "string" } },
+        "color": { "type": "string" },
+        "lineWeight": { "type": "number", "exclusiveMinimum": 0 },
+        "lineType": { "$ref": "#/$defs/LineType" }
       }
     },
     "SlabMember": {
@@ -262,7 +279,12 @@
         },
         "level": { "type": "number" },
         "rotation": { "type": "number" },
-        "tags": { "type": "array", "items": { "type": "string" } }
+        "tags": { "type": "array", "items": { "type": "string" } },
+        "color": { "type": "string" },
+        "lineWeight": { "type": "number", "exclusiveMinimum": 0 },
+        "lineType": { "$ref": "#/$defs/LineType" },
+        "fillColor": { "type": "string" },
+        "fillOpacity": { "type": "number", "minimum": 0, "maximum": 1 }
       }
     },
     "Opening": {
@@ -290,7 +312,9 @@
         "y": { "type": "number" },
         "text": { "type": "string" },
         "fontSize": { "type": "number", "exclusiveMinimum": 0 },
-        "rotation": { "type": "number" }
+        "rotation": { "type": "number" },
+        "color": { "type": "string" },
+        "textAlign": { "$ref": "#/$defs/TextAlign" }
       }
     },
     "Dimension": {
@@ -303,7 +327,10 @@
         "start": { "$ref": "#/$defs/Point2D" },
         "end": { "$ref": "#/$defs/Point2D" },
         "offset": { "type": "number" },
-        "text": { "type": "string" }
+        "text": { "type": "string" },
+        "color": { "type": "string" },
+        "lineWeight": { "type": "number", "exclusiveMinimum": 0 },
+        "lineType": { "$ref": "#/$defs/LineType" }
       }
     },
     "View": {


### PR DESCRIPTION
## Summary
- エンティティ単位の線種・線太さ・色の設定を追加（部材・注記・寸法線）
- テキスト回転の描画実装、テキスト配置(左/中/右)、複数行テキスト対応
- レイヤーロック機能追加（ロック中は選択不可）
- 寸法線の編集機能追加（offset・スタイル）、矢印を三角形に変更
- スラブの塗り色・透過設定、3Dビューの部材個別色対応
- SVG/DXF出力にエンティティ別スタイルを反映

## Changes

### Entity-level styling
| Property | Targets | Details |
|----------|---------|---------|
| `color` | Member, Annotation, Dimension | カラーピッカーで個別設定 |
| `lineWeight` | Member, Dimension | 数値指定（デフォルト20） |
| `lineType` | Member, Dimension | solid/dashed/dotted/chain/dashdot |
| `fillColor` / `fillOpacity` | Slab | 塗り色・透過度 |
| `textAlign` | Annotation | left/center/right |
| `rotation` | Annotation | 描画反映（型定義は既存） |

### New files
- `src/domain/rendering/lineStyle.ts` — LineType→SVG dasharray変換ユーティリティ

### Modified (17 files)
- Types, Schema, Store, 2D rendering layers, PropertyPanel, LayerPanel, i18n, SVG/DXF export, 3D MemberMesh, EditorInteraction

## Test plan
- [ ] `npm test` — 全27テスト通過確認済
- [ ] `npm run build` — ビルド成功確認済
- [ ] 既存JSONファイルの読み込み（新プロパティはすべてoptional）
- [ ] 部材選択 → PropertyPanelで色・線種・線太さを変更 → 2D/3Dに反映
- [ ] 注記のテキスト回転・配置・複数行入力
- [ ] 寸法線の矢印表示・offset編集・スタイル変更
- [ ] レイヤーロック → ロック中のエンティティが選択不可
- [ ] SVG/DXFエクスポートにスタイルが反映


🤖 Generated with [Claude Code](https://claude.com/claude-code)