### PR TITLE
Add 19 CAD productivity features: selection, transforms, editing, preview

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -16,6 +16,7 @@ import { ExportDialog } from '@/features/project/ExportDialog';
 import { MasterDataDialog } from '@/features/project/MasterDataDialog';
 import { AiAssistPanel } from '@/features/aiAssist/AiAssistPanel';
 import { HelpDialog } from '@/features/help/HelpDialog';
+import { PrintPreviewDialog } from '@/features/project/PrintPreviewDialog';
 
 export function App() {
   const viewMode = useEditorStore((s) => s.viewMode);
@@ -28,6 +29,7 @@ export function App() {
   const [showAi, setShowAi] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
   const [showTransform, setShowTransform] = useState(false);
+  const [showPrintPreview, setShowPrintPreview] = useState(false);
 
   useKeyboardShortcuts();
 
@@ -54,6 +56,7 @@ export function App() {
         onAiAssist={() => setShowAi(true)}
         onHelp={() => setShowHelp(true)}
         onTransform={() => setShowTransform(true)}
+        onPrintPreview={() => setShowPrintPreview(true)}
       />
       <div className="app-body">
         <div className="left-panel">
@@ -93,6 +96,7 @@ export function App() {
       {showAi && <AiAssistPanel onClose={() => setShowAi(false)} />}
       {showHelp && <HelpDialog onClose={() => setShowHelp(false)} />}
       {showTransform && <TransformDialog onClose={() => setShowTransform(false)} />}
+      {showPrintPreview && <PrintPreviewDialog onClose={() => setShowPrintPreview(false)} />}
     </div>
   );
 }

--- a/src/app/store/editorStore.ts
+++ b/src/app/store/editorStore.ts
@@ -79,6 +79,7 @@ interface EditorState {
   setLayerLocked: (layer: string, locked: boolean) => void;
   setWireframe: (on: boolean) => void;
   setOrthographic: (on: boolean) => void;
+  zoomToFit: (bounds: { minX: number; minY: number; maxX: number; maxY: number }, viewportWidth: number, viewportHeight: number) => void;
 }
 
 const defaultLayerVisibility: Record<string, boolean> = {};
@@ -135,4 +136,22 @@ export const useEditorStore = create<EditorState>()((set) => ({
     })),
   setWireframe: (on) => set({ wireframe: on }),
   setOrthographic: (on) => set({ orthographic: on }),
+  zoomToFit: (bounds, viewportWidth, viewportHeight) => {
+    const padding = 0.1;
+    const contentWidth = bounds.maxX - bounds.minX;
+    const contentHeight = bounds.maxY - bounds.minY;
+    if (contentWidth <= 0 && contentHeight <= 0) return;
+    const zoomX = contentWidth > 0 ? viewportWidth / (contentWidth * (1 + padding)) : 10;
+    const zoomY = contentHeight > 0 ? viewportHeight / (contentHeight * (1 + padding)) : 10;
+    const zoom = Math.max(0.001, Math.min(10, Math.min(zoomX, zoomY)));
+    const centerX = (bounds.minX + bounds.maxX) / 2;
+    const centerY = (bounds.minY + bounds.maxY) / 2;
+    set({
+      zoom,
+      pan: {
+        x: viewportWidth / 2 - centerX * zoom,
+        y: viewportHeight / 2 + centerY * zoom, // Y is flipped in SVG
+      },
+    });
+  },
 }));

--- a/src/app/store/editorStore.ts
+++ b/src/app/store/editorStore.ts
@@ -10,7 +10,9 @@ export type EditorTool =
   | 'dimension'
   | 'annotation'
   | 'trim'
-  | 'extend';
+  | 'extend'
+  | 'xline'
+  | 'spline';
 
 export type SnapMode = 'grid' | 'endpoint' | 'midpoint' | 'intersection' | 'perpendicular' | 'nearest';
 
@@ -23,6 +25,7 @@ export const LAYER_NAMES = [
   'opening',
   'dimension',
   'annotation',
+  'construction',
 ] as const;
 
 export type LayerName = (typeof LAYER_NAMES)[number];

--- a/src/app/store/editorStore.ts
+++ b/src/app/store/editorStore.ts
@@ -8,9 +8,11 @@ export type EditorTool =
   | 'wall'
   | 'slab'
   | 'dimension'
-  | 'annotation';
+  | 'annotation'
+  | 'trim'
+  | 'extend';
 
-export type SnapMode = 'grid' | 'endpoint' | 'midpoint' | 'intersection';
+export type SnapMode = 'grid' | 'endpoint' | 'midpoint' | 'intersection' | 'perpendicular' | 'nearest';
 
 export const LAYER_NAMES = [
   'grid',

--- a/src/app/store/projectStore.ts
+++ b/src/app/store/projectStore.ts
@@ -21,7 +21,11 @@ import {
   scaleSelection,
   stretchSelection,
   translateSelection,
+  offsetSelection,
+  mirrorSelection,
+  arraySelection,
   type StretchSelectionOptions,
+  type ArraySelectionOptions,
 } from '@/domain/structural/editTransform';
 
 export interface ProjectState {
@@ -45,6 +49,9 @@ export interface ProjectState {
   duplicateEntities: (ids: string[], dx: number, dy: number, count?: number) => string[];
   scaleEntities: (ids: string[], origin: Point2D, scaleX: number, scaleY: number) => void;
   stretchEntities: (ids: string[], options: StretchSelectionOptions) => void;
+  offsetEntities: (ids: string[], distance: number) => string[];
+  mirrorEntities: (ids: string[], axisStart: Point2D, axisEnd: Point2D, copy: boolean) => string[];
+  arrayEntities: (ids: string[], options: ArraySelectionOptions) => string[];
 
   // Annotation operations
   addAnnotation: (annotation: Annotation) => void;
@@ -275,6 +282,36 @@ export const useProjectStore = create<ProjectState>()(
           stretchSelection(state.data, ids, options);
           state.isDirty = true;
         }),
+
+      offsetEntities: (ids, distance) => {
+        let createdIds: string[] = [];
+        set((state) => {
+          if (!state.data || ids.length === 0) return;
+          createdIds = offsetSelection(state.data, ids, distance);
+          state.isDirty = true;
+        });
+        return createdIds;
+      },
+
+      mirrorEntities: (ids, axisStart, axisEnd, copy) => {
+        let createdIds: string[] = [];
+        set((state) => {
+          if (!state.data || ids.length === 0) return;
+          createdIds = mirrorSelection(state.data, ids, axisStart, axisEnd, copy);
+          state.isDirty = true;
+        });
+        return createdIds;
+      },
+
+      arrayEntities: (ids, options) => {
+        let createdIds: string[] = [];
+        set((state) => {
+          if (!state.data || ids.length === 0) return;
+          createdIds = arraySelection(state.data, ids, options);
+          state.isDirty = true;
+        });
+        return createdIds;
+      },
 
       // ── Annotations ──
 

--- a/src/app/store/projectStore.ts
+++ b/src/app/store/projectStore.ts
@@ -15,6 +15,7 @@ import type {
   Section,
   Sheet,
   PlanView,
+  Group,
 } from '@/domain/structural/types';
 import {
   duplicateSelection,
@@ -27,6 +28,7 @@ import {
   type StretchSelectionOptions,
   type ArraySelectionOptions,
 } from '@/domain/structural/editTransform';
+import { trimMember as trimMemberFn, extendMember as extendMemberFn, filletWalls as filletWallsFn } from '@/domain/structural/editTrim';
 
 export interface ProjectState {
   data: ProjectData | null;
@@ -85,6 +87,20 @@ export interface ProjectState {
   deleteSection: (id: string) => void;
   addPlanSheet: (storyId: string) => string | null;
   updateSheet: (id: string, updates: Partial<Sheet>) => void;
+
+  // Trim/Extend operations
+  trimMember: (memberId: string, cutPoint: Point2D, side: 'start' | 'end') => boolean;
+  extendMember: (memberId: string, targetMemberId: string) => boolean;
+  filletWalls: (wallId1: string, wallId2: string, radius?: number) => boolean;
+
+  // Slab vertex editing
+  updateSlabVertex: (memberId: string, vertexIndex: number, point: Point2D) => void;
+  addSlabVertex: (memberId: string, afterIndex: number) => void;
+  removeSlabVertex: (memberId: string, vertexIndex: number) => void;
+
+  // Grouping
+  createGroup: (ids: string[], name: string) => string | null;
+  ungroupSelection: (groupId: string) => void;
 
   // Generic delete by id (from any collection)
   deleteById: (id: string) => void;
@@ -596,6 +612,99 @@ export const useProjectStore = create<ProjectState>()(
           const sheet = state.data.sheets.find((item) => item.id === id);
           if (!sheet) return;
           Object.assign(sheet, updates);
+          state.isDirty = true;
+        }),
+
+      // ── Trim/Extend ──
+
+      trimMember: (memberId, cutPoint, side) => {
+        let result = false;
+        set((state) => {
+          if (!state.data) return;
+          result = trimMemberFn(state.data, memberId, cutPoint, side);
+          if (result) state.isDirty = true;
+        });
+        return result;
+      },
+
+      extendMember: (memberId, targetMemberId) => {
+        let result = false;
+        set((state) => {
+          if (!state.data) return;
+          result = extendMemberFn(state.data, memberId, targetMemberId);
+          if (result) state.isDirty = true;
+        });
+        return result;
+      },
+
+      filletWalls: (wallId1, wallId2, radius = 0) => {
+        let result = false;
+        set((state) => {
+          if (!state.data) return;
+          result = filletWallsFn(state.data, wallId1, wallId2, radius);
+          if (result) state.isDirty = true;
+        });
+        return result;
+      },
+
+      // ── Slab Vertex Editing ──
+
+      updateSlabVertex: (memberId, vertexIndex, point) =>
+        set((state) => {
+          if (!state.data) return;
+          const member = state.data.members.find((m) => m.id === memberId);
+          if (!member || member.type !== 'slab') return;
+          if (vertexIndex < 0 || vertexIndex >= member.polygon.length) return;
+          member.polygon[vertexIndex] = { x: point.x, y: point.y };
+          state.isDirty = true;
+        }),
+
+      addSlabVertex: (memberId, afterIndex) =>
+        set((state) => {
+          if (!state.data) return;
+          const member = state.data.members.find((m) => m.id === memberId);
+          if (!member || member.type !== 'slab') return;
+          const n = member.polygon.length;
+          if (afterIndex < 0 || afterIndex >= n) return;
+          const nextIndex = (afterIndex + 1) % n;
+          const midpoint = {
+            x: (member.polygon[afterIndex].x + member.polygon[nextIndex].x) / 2,
+            y: (member.polygon[afterIndex].y + member.polygon[nextIndex].y) / 2,
+          };
+          member.polygon.splice(afterIndex + 1, 0, midpoint);
+          state.isDirty = true;
+        }),
+
+      removeSlabVertex: (memberId, vertexIndex) =>
+        set((state) => {
+          if (!state.data) return;
+          const member = state.data.members.find((m) => m.id === memberId);
+          if (!member || member.type !== 'slab') return;
+          if (member.polygon.length <= 3) return; // minimum 3 vertices
+          if (vertexIndex < 0 || vertexIndex >= member.polygon.length) return;
+          member.polygon.splice(vertexIndex, 1);
+          state.isDirty = true;
+        }),
+
+      // ── Grouping ──
+
+      createGroup: (ids, name) => {
+        let groupId: string | null = null;
+        set((state) => {
+          if (!state.data || ids.length === 0) return;
+          if (!state.data.groups) state.data.groups = [];
+          groupId = uuidv4();
+          const group: Group = { id: groupId, name, memberIds: [...ids] };
+          state.data.groups.push(group);
+          state.isDirty = true;
+        });
+        return groupId;
+      },
+
+      ungroupSelection: (groupId) =>
+        set((state) => {
+          if (!state.data || !state.data.groups) return;
+          state.data.groups = state.data.groups.filter((g) => g.id !== groupId);
           state.isDirty = true;
         }),
 

--- a/src/app/store/projectStore.ts
+++ b/src/app/store/projectStore.ts
@@ -16,6 +16,9 @@ import type {
   Sheet,
   PlanView,
   Group,
+  ConstructionLine,
+  ExternalRef,
+  Viewport,
 } from '@/domain/structural/types';
 import {
   duplicateSelection,
@@ -101,6 +104,20 @@ export interface ProjectState {
   // Grouping
   createGroup: (ids: string[], name: string) => string | null;
   ungroupSelection: (groupId: string) => void;
+
+  // Construction Lines
+  addConstructionLine: (cl: ConstructionLine) => void;
+  deleteConstructionLine: (id: string) => void;
+
+  // External References
+  addExternalRef: (ref: ExternalRef) => void;
+  removeExternalRef: (id: string) => void;
+  toggleExternalRefVisibility: (id: string) => void;
+
+  // Viewports
+  addViewport: (viewport: Viewport) => void;
+  updateViewport: (id: string, updates: Partial<Viewport>) => void;
+  removeViewport: (id: string) => void;
 
   // Generic delete by id (from any collection)
   deleteById: (id: string) => void;
@@ -708,6 +725,88 @@ export const useProjectStore = create<ProjectState>()(
           state.isDirty = true;
         }),
 
+      // ── Construction Lines ──
+
+      addConstructionLine: (cl) =>
+        set((state) => {
+          if (!state.data) return;
+          if (!state.data.constructionLines) state.data.constructionLines = [];
+          state.data.constructionLines.push(cl);
+          state.isDirty = true;
+        }),
+
+      deleteConstructionLine: (id) =>
+        set((state) => {
+          if (!state.data || !state.data.constructionLines) return;
+          state.data.constructionLines = state.data.constructionLines.filter((cl) => cl.id !== id);
+          state.isDirty = true;
+        }),
+
+      // ── External References ──
+
+      addExternalRef: (ref) =>
+        set((state) => {
+          if (!state.data) return;
+          if (!state.data.externalRefs) state.data.externalRefs = [];
+          state.data.externalRefs.push(ref);
+          state.isDirty = true;
+        }),
+
+      removeExternalRef: (id) =>
+        set((state) => {
+          if (!state.data || !state.data.externalRefs) return;
+          state.data.externalRefs = state.data.externalRefs.filter((r) => r.id !== id);
+          state.isDirty = true;
+        }),
+
+      toggleExternalRefVisibility: (id) =>
+        set((state) => {
+          if (!state.data || !state.data.externalRefs) return;
+          const ref = state.data.externalRefs.find((r) => r.id === id);
+          if (ref) ref.visible = !ref.visible;
+          state.isDirty = true;
+        }),
+
+      // ── Viewports ──
+
+      addViewport: (viewport) =>
+        set((state) => {
+          if (!state.data) return;
+          const sheet = state.data.sheets.find((s) => s.id === viewport.sheetId);
+          if (!sheet) return;
+          if (!sheet.viewports) sheet.viewports = [];
+          sheet.viewports.push(viewport);
+          state.isDirty = true;
+        }),
+
+      updateViewport: (id, updates) =>
+        set((state) => {
+          if (!state.data) return;
+          for (const sheet of state.data.sheets) {
+            if (!sheet.viewports) continue;
+            const vp = sheet.viewports.find((v) => v.id === id);
+            if (vp) {
+              Object.assign(vp, updates);
+              state.isDirty = true;
+              return;
+            }
+          }
+        }),
+
+      removeViewport: (id) =>
+        set((state) => {
+          if (!state.data) return;
+          for (const sheet of state.data.sheets) {
+            if (!sheet.viewports) continue;
+            const idx = sheet.viewports.findIndex((v) => v.id === id);
+            if (idx >= 0) {
+              sheet.viewports.splice(idx, 1);
+              state.isDirty = true;
+              return;
+            }
+          }
+        }),
+
       // ── Generic delete ──
 
       deleteById: (id) =>
@@ -717,6 +816,9 @@ export const useProjectStore = create<ProjectState>()(
           state.data.openings = state.data.openings.filter((o) => o.id !== id && o.memberId !== id);
           state.data.annotations = state.data.annotations.filter((a) => a.id !== id);
           state.data.dimensions = state.data.dimensions.filter((d) => d.id !== id);
+          if (state.data.constructionLines) {
+            state.data.constructionLines = state.data.constructionLines.filter((cl) => cl.id !== id);
+          }
           state.isDirty = true;
         }),
     })),

--- a/src/app/useKeyboardShortcuts.ts
+++ b/src/app/useKeyboardShortcuts.ts
@@ -36,6 +36,25 @@ export function useKeyboardShortcuts() {
               }
             }
             return;
+          case 'g':
+            e.preventDefault();
+            {
+              const ids = useEditorStore.getState().selectedIds;
+              if (ids.length === 0) return;
+              if (e.shiftKey) {
+                // Ungroup: find group containing first selected id
+                const data = useProjectStore.getState().data;
+                if (data?.groups) {
+                  const group = data.groups.find((g) => g.memberIds.includes(ids[0]));
+                  if (group) useProjectStore.getState().ungroupSelection(group.id);
+                }
+              } else {
+                // Group
+                const name = prompt('Group name:') || 'Group';
+                useProjectStore.getState().createGroup(ids, name);
+              }
+            }
+            return;
         }
       }
 

--- a/src/components/panels/LayerPanel.tsx
+++ b/src/components/panels/LayerPanel.tsx
@@ -1,4 +1,4 @@
-import { useEditorStore, LAYER_NAMES } from '@/app/store';
+import { useEditorStore, useProjectStore, LAYER_NAMES } from '@/app/store';
 import { useI18n } from '@/i18n';
 import type { Translations } from '@/i18n';
 
@@ -11,10 +11,13 @@ const LAYER_LABEL_KEYS: Record<string, keyof Translations> = {
   opening: 'layerOpening',
   dimension: 'layerDimension',
   annotation: 'layerAnnotation',
+  construction: 'layerConstruction',
 };
 
 export function LayerPanel() {
   const { layerVisibility, toggleLayerVisibility, layerLocked, setLayerLocked } = useEditorStore();
+  const data = useProjectStore((s) => s.data);
+  const { toggleExternalRefVisibility, removeExternalRef } = useProjectStore();
   const { t } = useI18n();
 
   return (
@@ -48,6 +51,41 @@ export function LayerPanel() {
           </div>
         ))}
       </div>
+
+      {/* External References */}
+      {data?.externalRefs && data.externalRefs.length > 0 && (
+        <>
+          <div className="panel-header" style={{ marginTop: 8 }}>{t.xrefTitle}</div>
+          <div className="panel-content">
+            {data.externalRefs.map((ref) => (
+              <div key={ref.id} className="layer-row" style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                <label style={{ display: 'flex', alignItems: 'center', gap: '4px', flex: 1 }}>
+                  <input
+                    type="checkbox"
+                    checked={ref.visible}
+                    onChange={() => toggleExternalRefVisibility(ref.id)}
+                  />
+                  {ref.name}
+                </label>
+                <button
+                  onClick={() => removeExternalRef(ref.id)}
+                  style={{
+                    background: 'none',
+                    border: 'none',
+                    cursor: 'pointer',
+                    padding: '2px 4px',
+                    fontSize: '11px',
+                    color: 'var(--text-secondary)',
+                  }}
+                  title={t.xrefRemove}
+                >
+                  x
+                </button>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/panels/PropertyPanel.tsx
+++ b/src/components/panels/PropertyPanel.tsx
@@ -1,7 +1,8 @@
 import { useProjectStore, useEditorStore } from '@/app/store';
 import { useI18n } from '@/i18n';
 import type { Member, Annotation, Dimension, LineType, TextAlign } from '@/domain/structural/types';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
+import { polygonArea, polygonPerimeter, linearLength } from '@/domain/geometry/measurement';
 
 const LINE_TYPE_OPTIONS: LineType[] = ['solid', 'dashed', 'dotted', 'chain', 'dashdot'];
 const TEXT_ALIGN_OPTIONS: TextAlign[] = ['left', 'center', 'right'];
@@ -20,11 +21,23 @@ export function PropertyPanel() {
     );
   }
 
+  // Multi-selection: show group info if all belong to same group
   if (selectedIds.length > 1) {
+    const group = data.groups?.find((g) =>
+      selectedIds.every((id) => g.memberIds.includes(id)),
+    );
     return (
       <div>
         <div className="panel-header">{t.panelProperties}</div>
-        <div className="panel-content">{selectedIds.length} {t.objectsSelected}</div>
+        <div className="panel-content">
+          <div>{selectedIds.length} {t.objectsSelected}</div>
+          {group && (
+            <div className="prop-row" style={{ marginTop: 8 }}>
+              <span className="prop-label">{t.groupName}</span>
+              <span>{group.name}</span>
+            </div>
+          )}
+        </div>
       </div>
     );
   }
@@ -49,8 +62,30 @@ export function PropertyPanel() {
 
 function MemberProps({ member }: { member: Member }) {
   const updateMember = useProjectStore((s) => s.updateMember);
+  const updateSlabVertex = useProjectStore((s) => s.updateSlabVertex);
+  const addSlabVertex = useProjectStore((s) => s.addSlabVertex);
+  const removeSlabVertex = useProjectStore((s) => s.removeSlabVertex);
   const data = useProjectStore((s) => s.data)!;
   const { t } = useI18n();
+
+  // Measurement: area/perimeter for slabs, length for linear members
+  const measurement = useMemo((): { area?: number; perimeter?: number; length?: number } => {
+    if (member.type === 'slab') {
+      return {
+        area: polygonArea(member.polygon),
+        perimeter: polygonPerimeter(member.polygon),
+      };
+    }
+    return {
+      length: linearLength(
+        { x: member.start.x, y: member.start.y },
+        { x: member.end.x, y: member.end.y },
+      ),
+    };
+  }, [member]);
+
+  // Group info
+  const group = data.groups?.find((g) => g.memberIds.includes(member.id));
 
   return (
     <div>
@@ -70,6 +105,8 @@ function MemberProps({ member }: { member: Member }) {
             {data.sections.map((s) => <option key={s.id} value={s.id}>{s.id}</option>)}
           </select>
         </div>
+
+        {/* Linear member coordinates */}
         {member.type !== 'slab' && (
           <>
             <CoordRow label="Start X" value={member.start.x} onChange={(v) => updateMember(member.id, { start: { ...member.start, x: v } } as Partial<Member>)} />
@@ -78,6 +115,59 @@ function MemberProps({ member }: { member: Member }) {
             <CoordRow label="End Y" value={member.end.y} onChange={(v) => updateMember(member.id, { end: { ...member.end, y: v } } as Partial<Member>)} />
           </>
         )}
+
+        {/* Measurements */}
+        {measurement.length != null && (
+          <div className="prop-row">
+            <span className="prop-label">{t.propLength}</span>
+            <span>{measurement.length.toFixed(0)} mm</span>
+          </div>
+        )}
+        {measurement.area != null && measurement.perimeter != null && (
+          <>
+            <div className="prop-row">
+              <span className="prop-label">{t.propArea}</span>
+              <span>{(measurement.area / 1e6).toFixed(3)} m2</span>
+            </div>
+            <div className="prop-row">
+              <span className="prop-label">{t.propPerimeter}</span>
+              <span>{measurement.perimeter.toFixed(0)} mm</span>
+            </div>
+          </>
+        )}
+
+        {/* Slab vertex editing */}
+        {member.type === 'slab' && (
+          <div style={{ marginTop: 8 }}>
+            <div style={{ fontSize: 11, fontWeight: 600, marginBottom: 4 }}>{t.propVertices}</div>
+            {member.polygon.map((pt, i) => (
+              <div key={i} style={{ display: 'flex', gap: 4, alignItems: 'center', marginBottom: 2 }}>
+                <span style={{ fontSize: 10, width: 16, color: 'var(--text-secondary)' }}>{i}</span>
+                <VertexCoordInput
+                  value={pt.x}
+                  onChange={(v) => updateSlabVertex(member.id, i, { x: v, y: pt.y })}
+                />
+                <VertexCoordInput
+                  value={pt.y}
+                  onChange={(v) => updateSlabVertex(member.id, i, { x: pt.x, y: v })}
+                />
+                <button
+                  style={{ fontSize: 10, padding: '1px 4px', cursor: 'pointer', background: 'var(--border-color)', border: 'none', borderRadius: 2, color: 'var(--text-primary)' }}
+                  title={t.vertexAdd}
+                  onClick={() => addSlabVertex(member.id, i)}
+                >+</button>
+                {member.polygon.length > 3 && (
+                  <button
+                    style={{ fontSize: 10, padding: '1px 4px', cursor: 'pointer', background: 'var(--border-color)', border: 'none', borderRadius: 2, color: 'var(--text-primary)' }}
+                    title={t.vertexRemove}
+                    onClick={() => removeSlabVertex(member.id, i)}
+                  >-</button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
         {/* Style properties */}
         <div className="prop-row">
           <span className="prop-label">{t.propColor}</span>
@@ -98,6 +188,14 @@ function MemberProps({ member }: { member: Member }) {
             </div>
             <CoordRow label={t.propFillOpacity} value={member.fillOpacity ?? 0.1} onChange={(v) => updateMember(member.id, { fillOpacity: Math.max(0, Math.min(1, v)) } as Partial<Member>)} />
           </>
+        )}
+
+        {/* Group info */}
+        {group && (
+          <div className="prop-row" style={{ marginTop: 8 }}>
+            <span className="prop-label">{t.groupName}</span>
+            <span>{group.name}</span>
+          </div>
         )}
       </div>
     </div>
@@ -184,5 +282,25 @@ function CoordRow({ label, value, onChange }: { label: string; value: number; on
       <span className="prop-label">{label}</span>
       <input className="prop-input" value={text} onChange={(e) => setText(e.target.value)} onBlur={commit} onKeyDown={(e) => e.key === 'Enter' && commit()} />
     </div>
+  );
+}
+
+function VertexCoordInput({ value, onChange }: { value: number; onChange: (v: number) => void }) {
+  const [text, setText] = useState(String(Math.round(value)));
+  useEffect(() => { setText(String(Math.round(value))); }, [value]);
+  const commit = () => {
+    const num = parseFloat(text);
+    if (!isNaN(num) && num !== value) onChange(num);
+    else setText(String(Math.round(value)));
+  };
+  return (
+    <input
+      className="prop-input"
+      style={{ width: 60, fontSize: 10, padding: '1px 3px' }}
+      value={text}
+      onChange={(e) => setText(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e) => e.key === 'Enter' && commit()}
+    />
   );
 }

--- a/src/components/panels/PropertyPanel.tsx
+++ b/src/components/panels/PropertyPanel.tsx
@@ -202,38 +202,91 @@ function MemberProps({ member }: { member: Member }) {
   );
 }
 
+const FONT_FAMILY_OPTIONS = ['sans-serif', 'serif', 'monospace'];
+
 function AnnotationProps({ annotation }: { annotation: Annotation }) {
   const updateAnnotation = useProjectStore((s) => s.updateAnnotation);
   const { t } = useI18n();
+
+  const isSpline = annotation.type === 'spline';
 
   return (
     <div>
       <div className="panel-header">{t.panelProperties}</div>
       <div className="panel-content">
         <div className="prop-row"><span className="prop-label">{t.propId}</span><span>{annotation.id}</span></div>
-        <div className="prop-row">
-          <span className="prop-label">{t.propText}</span>
-          <textarea
-            className="prop-input"
-            value={annotation.text}
-            onChange={(e) => updateAnnotation(annotation.id, { text: e.target.value })}
-            rows={3}
-            style={{ resize: 'vertical', fontFamily: 'inherit', fontSize: 'inherit' }}
-          />
-        </div>
-        <CoordRow label="X" value={annotation.x} onChange={(v) => updateAnnotation(annotation.id, { x: v })} />
-        <CoordRow label="Y" value={annotation.y} onChange={(v) => updateAnnotation(annotation.id, { y: v })} />
-        <div className="prop-row">
-          <span className="prop-label">{t.propColor}</span>
-          <input type="color" value={annotation.color ?? '#000000'} onChange={(e) => updateAnnotation(annotation.id, { color: e.target.value })} />
-        </div>
-        <div className="prop-row">
-          <span className="prop-label">{t.propTextAlign}</span>
-          <select className="prop-select" value={annotation.textAlign ?? 'left'} onChange={(e) => updateAnnotation(annotation.id, { textAlign: e.target.value as TextAlign })}>
-            {TEXT_ALIGN_OPTIONS.map((ta) => <option key={ta} value={ta}>{ta}</option>)}
-          </select>
-        </div>
-        <CoordRow label={t.propRotation} value={annotation.rotation ?? 0} onChange={(v) => updateAnnotation(annotation.id, { rotation: v })} />
+        <div className="prop-row"><span className="prop-label">{t.propType}</span><span>{annotation.type}</span></div>
+        {!isSpline && (
+          <>
+            <div className="prop-row">
+              <span className="prop-label">{t.propText}</span>
+              <textarea
+                className="prop-input"
+                value={annotation.text}
+                onChange={(e) => updateAnnotation(annotation.id, { text: e.target.value })}
+                rows={3}
+                style={{ resize: 'vertical', fontFamily: 'inherit', fontSize: 'inherit' }}
+              />
+            </div>
+            <CoordRow label="X" value={annotation.x} onChange={(v) => updateAnnotation(annotation.id, { x: v })} />
+            <CoordRow label="Y" value={annotation.y} onChange={(v) => updateAnnotation(annotation.id, { y: v })} />
+            <div className="prop-row">
+              <span className="prop-label">{t.propColor}</span>
+              <input type="color" value={annotation.color ?? '#000000'} onChange={(e) => updateAnnotation(annotation.id, { color: e.target.value })} />
+            </div>
+            <div className="prop-row">
+              <span className="prop-label">{t.propTextAlign}</span>
+              <select className="prop-select" value={annotation.textAlign ?? 'left'} onChange={(e) => updateAnnotation(annotation.id, { textAlign: e.target.value as TextAlign })}>
+                {TEXT_ALIGN_OPTIONS.map((ta) => <option key={ta} value={ta}>{ta}</option>)}
+              </select>
+            </div>
+            <CoordRow label={t.propRotation} value={annotation.rotation ?? 0} onChange={(v) => updateAnnotation(annotation.id, { rotation: v })} />
+
+            {/* Text Formatting */}
+            <div className="prop-row" style={{ marginTop: 8 }}>
+              <span className="prop-label">{t.propFontWeight}</span>
+              <button
+                className={`toolbar-btn ${annotation.fontWeight === 'bold' ? 'active' : ''}`}
+                style={{ minWidth: 32, fontWeight: 'bold' }}
+                onClick={() => updateAnnotation(annotation.id, { fontWeight: annotation.fontWeight === 'bold' ? 'normal' : 'bold' })}
+              >B</button>
+            </div>
+            <div className="prop-row">
+              <span className="prop-label">{t.propFontStyle}</span>
+              <button
+                className={`toolbar-btn ${annotation.fontStyle === 'italic' ? 'active' : ''}`}
+                style={{ minWidth: 32, fontStyle: 'italic' }}
+                onClick={() => updateAnnotation(annotation.id, { fontStyle: annotation.fontStyle === 'italic' ? 'normal' : 'italic' })}
+              >I</button>
+            </div>
+            <div className="prop-row">
+              <span className="prop-label">{t.propTextDecoration}</span>
+              <button
+                className={`toolbar-btn ${annotation.textDecoration === 'underline' ? 'active' : ''}`}
+                style={{ minWidth: 32, textDecoration: 'underline' }}
+                onClick={() => updateAnnotation(annotation.id, { textDecoration: annotation.textDecoration === 'underline' ? 'none' : 'underline' })}
+              >U</button>
+            </div>
+            <div className="prop-row">
+              <span className="prop-label">{t.propFontFamily}</span>
+              <select className="prop-select" value={annotation.fontFamily ?? 'sans-serif'} onChange={(e) => updateAnnotation(annotation.id, { fontFamily: e.target.value })}>
+                {FONT_FAMILY_OPTIONS.map((ff) => <option key={ff} value={ff}>{ff}</option>)}
+              </select>
+            </div>
+          </>
+        )}
+        {isSpline && (
+          <>
+            <div className="prop-row">
+              <span className="prop-label">{t.propColor}</span>
+              <input type="color" value={annotation.color ?? '#000000'} onChange={(e) => updateAnnotation(annotation.id, { color: e.target.value })} />
+            </div>
+            <div className="prop-row">
+              <span className="prop-label">Points</span>
+              <span>{annotation.points?.length ?? 0}</span>
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/components/toolbars/MainToolbar.tsx
+++ b/src/components/toolbars/MainToolbar.tsx
@@ -9,6 +9,7 @@ import { importIfc } from '@/domain/integration/ifc';
 import { importStructuralAnalysisJson, STRUCTURAL_ANALYSIS_SCHEMA } from '@/domain/integration/structuralAnalysisJson';
 import sampleProject from '@/samples/sample-project.json';
 import type { ProjectData } from '@/domain/structural/types';
+import { getAllEntityBounds, getSelectionBounds } from '@/domain/structural/editTransform';
 
 interface Props {
   onExport: () => void;
@@ -175,6 +176,42 @@ export function MainToolbar({ onExport, onMasters, onAiAssist, onHelp, onTransfo
       <div className="toolbar-group">
         <button className={`toolbar-btn ${viewMode === '2d' ? 'active' : ''}`} onClick={() => setViewMode('2d')}>{t.view2d}</button>
         <button className={`toolbar-btn ${viewMode === '3d' ? 'active' : ''}`} onClick={() => setViewMode('3d')}>{t.view3d}</button>
+        <button
+          className="toolbar-btn"
+          disabled={!data}
+          title={t.zoomExtents}
+          onClick={() => {
+            if (!data) return;
+            const el = document.querySelector('svg');
+            if (!el) return;
+            const rect = el.getBoundingClientRect();
+            const allBounds = getAllEntityBounds(data, activeStory);
+            if (!allBounds) return;
+            useEditorStore.getState().zoomToFit(allBounds, rect.width, rect.height);
+          }}
+        >
+          {t.zoomExtents}
+        </button>
+        <button
+          className="toolbar-btn"
+          disabled={selectedIds.length === 0 || !data}
+          title={t.zoomSelection}
+          onClick={() => {
+            if (!data) return;
+            const el = document.querySelector('svg');
+            if (!el) return;
+            const rect = el.getBoundingClientRect();
+            const bounds = getSelectionBounds(data, selectedIds);
+            if (!bounds) return;
+            useEditorStore.getState().zoomToFit(
+              { minX: bounds.min.x, minY: bounds.min.y, maxX: bounds.max.x, maxY: bounds.max.y },
+              rect.width,
+              rect.height,
+            );
+          }}
+        >
+          {t.zoomSelection}
+        </button>
       </div>
 
       <div className="toolbar-group">

--- a/src/components/toolbars/MainToolbar.tsx
+++ b/src/components/toolbars/MainToolbar.tsx
@@ -17,9 +17,10 @@ interface Props {
   onAiAssist: () => void;
   onHelp: () => void;
   onTransform: () => void;
+  onPrintPreview: () => void;
 }
 
-export function MainToolbar({ onExport, onMasters, onAiAssist, onHelp, onTransform }: Props) {
+export function MainToolbar({ onExport, onMasters, onAiAssist, onHelp, onTransform, onPrintPreview }: Props) {
   const { data, isDirty, fileHandle, loadProject, newProject, setFileHandle, markClean, addAnnotations } =
     useProjectStore();
   const { viewMode, setViewMode, activeTool, setActiveTool, setSelectedIds, selectedIds, theme, toggleTheme, activeStory } =
@@ -171,6 +172,8 @@ export function MainToolbar({ onExport, onMasters, onAiAssist, onHelp, onTransfo
         {toolBtn('slab', t.toolSlab)}
         {toolBtn('dimension', t.toolDimension)}
         {toolBtn('annotation', t.toolAnnotation)}
+        {toolBtn('trim', t.toolTrim)}
+        {toolBtn('extend', t.toolExtend)}
       </div>
 
       <div className="toolbar-group">
@@ -216,6 +219,7 @@ export function MainToolbar({ onExport, onMasters, onAiAssist, onHelp, onTransfo
 
       <div className="toolbar-group">
         <button className="toolbar-btn" onClick={onExport} disabled={!data}>{t.fileExport}</button>
+        <button className="toolbar-btn" onClick={onPrintPreview} disabled={!data}>{t.printPreview}</button>
         <button className="toolbar-btn" onClick={onMasters} disabled={!data}>{mastersLabel}</button>
         <button className="toolbar-btn" onClick={onAiAssist}>{t.btnAi}</button>
         <button className="toolbar-btn" onClick={onHelp}>{t.btnHelp}</button>

--- a/src/components/toolbars/MainToolbar.tsx
+++ b/src/components/toolbars/MainToolbar.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useEditorStore, useProjectStore } from '@/app/store';
 import type { EditorTool } from '@/app/store';
 import { useI18n } from '@/i18n';
@@ -10,6 +11,7 @@ import { importStructuralAnalysisJson, STRUCTURAL_ANALYSIS_SCHEMA } from '@/doma
 import sampleProject from '@/samples/sample-project.json';
 import type { ProjectData } from '@/domain/structural/types';
 import { getAllEntityBounds, getSelectionBounds } from '@/domain/structural/editTransform';
+import { drawingTemplates } from '@/domain/templates/drawingTemplates';
 
 interface Props {
   onExport: () => void;
@@ -21,7 +23,7 @@ interface Props {
 }
 
 export function MainToolbar({ onExport, onMasters, onAiAssist, onHelp, onTransform, onPrintPreview }: Props) {
-  const { data, isDirty, fileHandle, loadProject, newProject, setFileHandle, markClean, addAnnotations } =
+  const { data, isDirty, fileHandle, loadProject, newProject, setFileHandle, markClean, addAnnotations, addExternalRef } =
     useProjectStore();
   const { viewMode, setViewMode, activeTool, setActiveTool, setSelectedIds, selectedIds, theme, toggleTheme, activeStory } =
     useEditorStore();
@@ -30,10 +32,52 @@ export function MainToolbar({ onExport, onMasters, onAiAssist, onHelp, onTransfo
   const importDxfLabel = locale === 'ja' ? 'DXF取込' : 'DXF Import';
   const importIfcLabel = locale === 'ja' ? 'IFC取込' : 'IFC Import';
   const transformLabel = locale === 'ja' ? '変形' : 'Transform';
+  const xrefLabel = locale === 'ja' ? '外部参照' : 'Xref';
+
+  const [showTemplatePicker, setShowTemplatePicker] = useState(false);
 
   const handleNew = () => {
     if (isDirty && !confirm(t.confirmUnsaved)) return;
-    newProject();
+    setShowTemplatePicker(true);
+  };
+
+  const handleTemplateSelect = (templateKey: string | null) => {
+    setShowTemplatePicker(false);
+    if (templateKey === null) {
+      // Blank project (default)
+      newProject();
+      return;
+    }
+    const template = drawingTemplates.find((t) => t.key === templateKey);
+    if (template) {
+      const projectData = template.create();
+      loadProject(projectData);
+    } else {
+      newProject();
+    }
+  };
+
+  const handleImportXref = async () => {
+    if (!data) return;
+    try {
+      const result = await openJsonFile();
+      const imported = importProjectJson(result.content);
+      if (!imported.ok) {
+        alert(imported.errors.map((e) => e.message).join('\n'));
+        return;
+      }
+      const ref = {
+        id: `xref-${Date.now()}`,
+        name: imported.data.project.name || 'Xref',
+        data: imported.data,
+        offsetX: 0,
+        offsetY: 0,
+        visible: true,
+      };
+      addExternalRef(ref);
+    } catch {
+      // User cancelled
+    }
   };
 
   const handleOpen = async () => {
@@ -150,6 +194,7 @@ export function MainToolbar({ onExport, onMasters, onAiAssist, onHelp, onTransfo
         <button className="toolbar-btn" onClick={handleSample}>{t.fileSample}</button>
         <button className="toolbar-btn" onClick={handleImportIfc}>{importIfcLabel}</button>
         <button className="toolbar-btn" onClick={handleImportDxf} disabled={!data}>{importDxfLabel}</button>
+        <button className="toolbar-btn" onClick={handleImportXref} disabled={!data}>{xrefLabel}</button>
       </div>
 
       <div className="toolbar-group">
@@ -174,6 +219,8 @@ export function MainToolbar({ onExport, onMasters, onAiAssist, onHelp, onTransfo
         {toolBtn('annotation', t.toolAnnotation)}
         {toolBtn('trim', t.toolTrim)}
         {toolBtn('extend', t.toolExtend)}
+        {toolBtn('xline', t.toolXline)}
+        {toolBtn('spline', t.toolSpline)}
       </div>
 
       <div className="toolbar-group">
@@ -233,6 +280,57 @@ export function MainToolbar({ onExport, onMasters, onAiAssist, onHelp, onTransfo
           {locale === 'ja' ? 'EN' : 'JA'}
         </button>
       </div>
+
+      {/* Template Picker Dialog */}
+      {showTemplatePicker && (
+        <div
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'var(--bg-modal-overlay)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 1000,
+          }}
+          onClick={() => setShowTemplatePicker(false)}
+        >
+          <div
+            style={{
+              background: 'var(--bg-modal)',
+              borderRadius: 8,
+              padding: 24,
+              minWidth: 340,
+              maxWidth: 'min(500px, calc(100vw - 32px))',
+              boxShadow: '0 8px 32px rgba(0,0,0,0.2)',
+              color: 'var(--text-primary)',
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 style={{ margin: '0 0 12px 0', fontSize: 16 }}>{t.templatePickerTitle}</h3>
+            <p style={{ fontSize: 12, color: 'var(--text-secondary)', margin: '0 0 16px 0' }}>{t.templateSelectPrompt}</p>
+            <div style={{ display: 'grid', gap: 8 }}>
+              {drawingTemplates.map((tmpl) => (
+                <button
+                  key={tmpl.key}
+                  className="toolbar-btn"
+                  style={{ textAlign: 'left', padding: '10px 14px', fontSize: 13 }}
+                  onClick={() => handleTemplateSelect(tmpl.key)}
+                >
+                  {locale === 'ja' ? tmpl.labelJa : tmpl.labelEn}
+                </button>
+              ))}
+              <button
+                className="toolbar-btn"
+                style={{ textAlign: 'left', padding: '10px 14px', fontSize: 13 }}
+                onClick={() => handleTemplateSelect(null)}
+              >
+                {locale === 'ja' ? '空白プロジェクト' : 'Blank Project'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/domain/export/dxfExport.ts
+++ b/src/domain/export/dxfExport.ts
@@ -25,6 +25,7 @@ export function exportDxf(data: ProjectData, storyId: string): string {
     { name: 'SLAB', color: 6 },      // magenta
     { name: 'DIMENSION', color: 7 }, // white
     { name: 'ANNOTATION', color: 7 },
+    { name: 'CONSTRUCTION', color: 8 }, // gray
   ];
 
   for (const layer of layerDefs) {
@@ -82,10 +83,29 @@ export function exportDxf(data: ProjectData, storyId: string): string {
   // Annotations
   const annotations = data.annotations.filter((a) => a.story === storyId);
   for (const a of annotations) {
+    if (a.type === 'spline' && a.points && a.points.length >= 2) {
+      addSpline(lines, 'ANNOTATION', a.points);
+      continue;
+    }
     if (a.text.includes('\n')) {
       addMText(lines, 'ANNOTATION', a.x, a.y, a.fontSize ?? 250, a.text, a.rotation);
     } else {
       addText(lines, 'ANNOTATION', a.x, a.y, a.fontSize ?? 250, a.text, a.rotation);
+    }
+  }
+
+  // Construction Lines
+  const constructionLines = (data.constructionLines ?? []).filter((cl) => cl.story === storyId);
+  for (const cl of constructionLines) {
+    const ext = 500000;
+    if (cl.type === 'xline') {
+      addLine(lines, 'CONSTRUCTION',
+        cl.origin.x - cl.direction.x * ext, cl.origin.y - cl.direction.y * ext,
+        cl.origin.x + cl.direction.x * ext, cl.origin.y + cl.direction.y * ext);
+    } else {
+      addLine(lines, 'CONSTRUCTION',
+        cl.origin.x, cl.origin.y,
+        cl.origin.x + cl.direction.x * ext, cl.origin.y + cl.direction.y * ext);
     }
   }
 
@@ -195,4 +215,16 @@ function addMText(lines: string[], layer: string, x: number, y: number, height: 
   }
   const encoded = text.replace(/\r?\n/g, '\\P');
   lines.push('1', encoded);
+}
+
+function addSpline(lines: string[], layer: string, points: { x: number; y: number }[]) {
+  // Export as SPLINE entity (degree 3 cubic)
+  lines.push('0', 'SPLINE');
+  lines.push('8', layer);
+  lines.push('70', '8'); // Planar flag
+  lines.push('71', '3'); // Degree 3 (cubic)
+  lines.push('73', String(points.length)); // Number of control points
+  for (const p of points) {
+    lines.push('10', String(p.x), '20', String(p.y), '30', '0');
+  }
 }

--- a/src/domain/export/svgExport.ts
+++ b/src/domain/export/svgExport.ts
@@ -117,6 +117,40 @@ export function exportSvg(data: ProjectData, sheetId: string): string {
   }
 
   svgLines.push(`</g>`);
+
+  // Render additional viewports if defined
+  if (sheet.viewports && sheet.viewports.length > 0) {
+    for (const vp of sheet.viewports) {
+      const vpView = data.views.find((v) => v.id === vp.viewId && v.type === 'plan');
+      if (!vpView || !('story' in vpView)) continue;
+      const vpStoryId = vpView.story;
+      const vpCenter = 'center' in vpView ? vpView.center : { x: 4000, y: 3000 };
+      const vpScaleNum = parseScale(vp.scale);
+      const vpScale = 1 / vpScaleNum;
+      const vpMembers = data.members.filter((m) => m.story === vpStoryId);
+      const vpAnnotations = data.annotations.filter((a) => a.story === vpStoryId);
+      const vpDimensions = data.dimensions.filter((d) => d.story === vpStoryId);
+
+      const vpOffX = vp.x + vp.width / 2 - vpCenter.x * vpScale;
+      const vpOffY = vp.y + vp.height / 2 + vpCenter.y * vpScale;
+
+      const clipId = `vp-clip-${vp.id}`;
+      svgLines.push(`<defs><clipPath id="${clipId}"><rect x="${vp.x}" y="${vp.y}" width="${vp.width}" height="${vp.height}"/></clipPath></defs>`);
+      svgLines.push(`<rect x="${vp.x}" y="${vp.y}" width="${vp.width}" height="${vp.height}" fill="none" stroke="#999" stroke-width="0.3" stroke-dasharray="2 2"/>`);
+      svgLines.push(`<g clip-path="url(#${clipId})">`);
+      svgLines.push(`<g transform="translate(${vpOffX}, ${vpOffY}) scale(${vpScale}, ${-vpScale})">`);
+      for (const m of vpMembers) svgLines.push(renderMemberSvg(m, data.sections));
+      for (const d of vpDimensions) svgLines.push(renderDimensionSvg(d));
+      for (const a of vpAnnotations) {
+        const fs = a.fontSize ?? 300;
+        const fillColor = a.color ?? '#34495e';
+        svgLines.push(`  <text x="${a.x}" y="${a.y}" font-size="${fs}" fill="${escapeXml(fillColor)}" transform="translate(0,0) scale(1,-1) translate(0,${-2 * a.y})">${escapeXml(a.text)}</text>`);
+      }
+      svgLines.push(`</g>`);
+      svgLines.push(`</g>`);
+    }
+  }
+
   svgLines.push(`</svg>`);
 
   return svgLines.join('\n');

--- a/src/domain/export/svgExport.ts
+++ b/src/domain/export/svgExport.ts
@@ -82,6 +82,14 @@ export function exportSvg(data: ProjectData, sheetId: string): string {
 
   // Annotations
   for (const a of annotations) {
+    // Spline annotation
+    if (a.type === 'spline' && a.points && a.points.length >= 2) {
+      const pathD = catmullRomToSvgPath(a.points);
+      const strokeColor = a.color ?? '#34495e';
+      svgLines.push(`  <path class="layer-annotation" d="${pathD}" fill="none" stroke="${escapeXml(strokeColor)}" stroke-width="20"/>`);
+      continue;
+    }
+
     const fs = a.fontSize ?? 300;
     const fillColor = a.color ?? '#34495e';
     const anchor = textAlignToAnchor(a.textAlign);
@@ -90,10 +98,16 @@ export function exportSvg(data: ProjectData, sheetId: string): string {
     const transform = `translate(0,0) scale(1,-1) translate(0,${-2 * a.y})${rotateAttr}`;
     const lines = a.text.split('\n');
 
+    const fwAttr = a.fontWeight === 'bold' ? ' font-weight="bold"' : '';
+    const fsAttr = a.fontStyle === 'italic' ? ' font-style="italic"' : '';
+    const tdAttr = a.textDecoration === 'underline' ? ' text-decoration="underline"' : '';
+    const ffAttr = a.fontFamily ? ` font-family="${escapeXml(a.fontFamily)}"` : '';
+    const styleAttrs = `${fwAttr}${fsAttr}${tdAttr}${ffAttr}`;
+
     if (lines.length <= 1) {
-      svgLines.push(`  <text class="layer-annotation" x="${a.x}" y="${a.y}" font-size="${fs}" fill="${escapeXml(fillColor)}" text-anchor="${anchor}" transform="${transform}">${escapeXml(a.text)}</text>`);
+      svgLines.push(`  <text class="layer-annotation" x="${a.x}" y="${a.y}" font-size="${fs}" fill="${escapeXml(fillColor)}" text-anchor="${anchor}" transform="${transform}"${styleAttrs}>${escapeXml(a.text)}</text>`);
     } else {
-      svgLines.push(`  <text class="layer-annotation" x="${a.x}" y="${a.y}" font-size="${fs}" fill="${escapeXml(fillColor)}" text-anchor="${anchor}" transform="${transform}">`);
+      svgLines.push(`  <text class="layer-annotation" x="${a.x}" y="${a.y}" font-size="${fs}" fill="${escapeXml(fillColor)}" text-anchor="${anchor}" transform="${transform}"${styleAttrs}>`);
       for (let i = 0; i < lines.length; i++) {
         const dy = i === 0 ? 0 : fs * 1.2;
         svgLines.push(`    <tspan x="${a.x}" dy="${dy}">${escapeXml(lines[i])}</tspan>`);
@@ -260,6 +274,26 @@ function renderTitleBlockSvg(sheet: Sheet, projectName: string, paperWidth: numb
         `</g>`,
       ].filter(Boolean).join('\n');
   }
+}
+
+function catmullRomToSvgPath(pts: { x: number; y: number }[]): string {
+  if (pts.length < 2) return '';
+  if (pts.length === 2) {
+    return `M ${pts[0].x},${pts[0].y} L ${pts[1].x},${pts[1].y}`;
+  }
+  const d: string[] = [`M ${pts[0].x},${pts[0].y}`];
+  for (let i = 0; i < pts.length - 1; i++) {
+    const p0 = pts[Math.max(0, i - 1)];
+    const p1 = pts[i];
+    const p2 = pts[i + 1];
+    const p3 = pts[Math.min(pts.length - 1, i + 2)];
+    const cp1x = p1.x + (p2.x - p0.x) / 6;
+    const cp1y = p1.y + (p2.y - p0.y) / 6;
+    const cp2x = p2.x - (p3.x - p1.x) / 6;
+    const cp2y = p2.y - (p3.y - p1.y) / 6;
+    d.push(`C ${cp1x},${cp1y} ${cp2x},${cp2y} ${p2.x},${p2.y}`);
+  }
+  return d.join(' ');
 }
 
 function escapeXml(s: string): string {

--- a/src/domain/geometry/measurement.ts
+++ b/src/domain/geometry/measurement.ts
@@ -1,0 +1,42 @@
+import type { Point2D } from './types';
+
+/**
+ * Compute the area of a polygon using the Shoelace formula.
+ * Returns absolute area (always positive).
+ */
+export function polygonArea(points: Point2D[]): number {
+  const n = points.length;
+  if (n < 3) return 0;
+  let sum = 0;
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n;
+    sum += points[i].x * points[j].y;
+    sum -= points[j].x * points[i].y;
+  }
+  return Math.abs(sum) / 2;
+}
+
+/**
+ * Compute the perimeter of a polygon.
+ */
+export function polygonPerimeter(points: Point2D[]): number {
+  const n = points.length;
+  if (n < 2) return 0;
+  let perimeter = 0;
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n;
+    const dx = points[j].x - points[i].x;
+    const dy = points[j].y - points[i].y;
+    perimeter += Math.sqrt(dx * dx + dy * dy);
+  }
+  return perimeter;
+}
+
+/**
+ * Compute the length of a linear member from start to end (2D).
+ */
+export function linearLength(start: Point2D, end: Point2D): number {
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+  return Math.sqrt(dx * dx + dy * dy);
+}

--- a/src/domain/geometry/snap.ts
+++ b/src/domain/geometry/snap.ts
@@ -1,18 +1,36 @@
 import type { Point2D } from './types';
 import type { SnapMode } from '@/app/store/editorStore';
-import { distance2D, midpoint2D } from './point';
+import { distance2D, midpoint2D, sub2D, dot2D } from './point';
 import { snapPointToGrid } from './transform';
 
 export interface SnapCandidate {
   id: string;
   endpoints: Point2D[];
   midpoints: Point2D[];
+  /** Edge segments for perpendicular/nearest snap: pairs [start, end] */
+  edges?: Array<[Point2D, Point2D]>;
 }
 
 export interface SnapResult {
   point: Point2D;
   type: SnapMode;
   sourceId?: string;
+}
+
+/**
+ * Project cursor onto segment a-b, returning the closest point on the segment
+ * and the parameter t in [0,1].
+ */
+function projectPointOnSegment(cursor: Point2D, a: Point2D, b: Point2D): { point: Point2D; t: number } {
+  const ab = sub2D(b, a);
+  const ac = sub2D(cursor, a);
+  const lenSq = ab.x * ab.x + ab.y * ab.y;
+  if (lenSq < 1e-20) return { point: a, t: 0 };
+  const t = Math.max(0, Math.min(1, dot2D(ac, ab) / lenSq));
+  return {
+    point: { x: a.x + ab.x * t, y: a.y + ab.y * t },
+    t,
+  };
 }
 
 export function findSnap(
@@ -53,7 +71,40 @@ export function findSnap(
     }
   }
 
-  // 3. Grid snap (lowest priority)
+  // 3. Perpendicular snap — snap to the foot of the perpendicular from cursor to each edge
+  if (activeSnapModes.includes('perpendicular')) {
+    for (const c of candidates) {
+      if (!c.edges) continue;
+      for (const [a, b] of c.edges) {
+        const proj = projectPointOnSegment(cursor, a, b);
+        // Only consider if the perpendicular foot is interior to the segment (not at endpoints)
+        if (proj.t > 0.01 && proj.t < 0.99) {
+          const d = distance2D(cursor, proj.point);
+          if (d < bestDist) {
+            bestDist = d;
+            best = { point: proj.point, type: 'perpendicular', sourceId: c.id };
+          }
+        }
+      }
+    }
+  }
+
+  // 4. Nearest snap — snap to the closest point on any edge
+  if (activeSnapModes.includes('nearest') && !best) {
+    for (const c of candidates) {
+      if (!c.edges) continue;
+      for (const [a, b] of c.edges) {
+        const proj = projectPointOnSegment(cursor, a, b);
+        const d = distance2D(cursor, proj.point);
+        if (d < bestDist) {
+          bestDist = d;
+          best = { point: proj.point, type: 'nearest', sourceId: c.id };
+        }
+      }
+    }
+  }
+
+  // 5. Grid snap (lowest priority)
   if (activeSnapModes.includes('grid') && !best) {
     const snapped = snapPointToGrid(cursor, gridSpacing);
     const d = distance2D(cursor, snapped);
@@ -82,11 +133,15 @@ export function buildSnapCandidatesFromMembers(
   for (const m of members) {
     const endpoints: Point2D[] = [];
     const midpoints: Point2D[] = [];
+    const edges: Array<[Point2D, Point2D]> = [];
 
     if (m.start && m.end) {
-      endpoints.push({ x: m.start.x, y: m.start.y });
-      endpoints.push({ x: m.end.x, y: m.end.y });
-      midpoints.push(midpoint2D({ x: m.start.x, y: m.start.y }, { x: m.end.x, y: m.end.y }));
+      const s: Point2D = { x: m.start.x, y: m.start.y };
+      const e: Point2D = { x: m.end.x, y: m.end.y };
+      endpoints.push(s);
+      endpoints.push(e);
+      midpoints.push(midpoint2D(s, e));
+      edges.push([s, e]);
     }
     if (m.polygon) {
       for (const p of m.polygon) {
@@ -95,11 +150,12 @@ export function buildSnapCandidatesFromMembers(
       for (let i = 0; i < m.polygon.length; i++) {
         const next = m.polygon[(i + 1) % m.polygon.length];
         midpoints.push(midpoint2D(m.polygon[i], next));
+        edges.push([m.polygon[i], next]);
       }
     }
 
     if (endpoints.length > 0) {
-      candidates.push({ id: m.id, endpoints, midpoints });
+      candidates.push({ id: m.id, endpoints, midpoints, edges });
     }
   }
 

--- a/src/domain/structural/editTransform.ts
+++ b/src/domain/structural/editTransform.ts
@@ -3,6 +3,13 @@ import type { Point2D } from '@/domain/geometry/types';
 import { dot2D, midpoint2D, normalize2D, perpendicular2D, sub2D } from '@/domain/geometry/point';
 import type { Annotation, Dimension, Member, Opening, ProjectData } from './types';
 
+export interface ArraySelectionOptions {
+  columns: number;
+  rows: number;
+  colSpacing: number;
+  rowSpacing: number;
+}
+
 export interface SelectionBounds {
   min: Point2D;
   max: Point2D;
@@ -352,4 +359,264 @@ export function stretchSelection(
   }));
 
   return bounds;
+}
+
+// ── Offset (parallel copy) ──
+
+export function offsetSelection(
+  data: ProjectData,
+  ids: string[],
+  distance: number,
+): string[] {
+  const selectedIds = new Set(ids);
+  const createdIds: string[] = [];
+
+  for (const member of [...data.members]) {
+    if (!selectedIds.has(member.id)) continue;
+
+    if (member.type === 'slab') continue; // skip slabs
+
+    const dir = normalize2D(sub2D(
+      { x: member.end.x, y: member.end.y },
+      { x: member.start.x, y: member.start.y },
+    ));
+    const perp = perpendicular2D(dir);
+    const dx = perp.x * distance;
+    const dy = perp.y * distance;
+
+    const clone = deepClone(member);
+    clone.id = uuidv4();
+    clone.start.x += dx;
+    clone.start.y += dy;
+    clone.end.x += dx;
+    clone.end.y += dy;
+    data.members.push(clone);
+    createdIds.push(clone.id);
+  }
+
+  // Offset columns in X direction
+  for (const member of [...data.members]) {
+    if (!selectedIds.has(member.id)) continue;
+    if (member.type !== 'column') continue;
+    // Already handled above for columns (they have start/end) but the
+    // perpendicular of a zero-length vector is {0,0}. Handle as X offset:
+    if (member.start.x === member.end.x && member.start.y === member.end.y) {
+      const clone = deepClone(member);
+      clone.id = uuidv4();
+      clone.start.x += distance;
+      clone.end.x += distance;
+      data.members.push(clone);
+      // Remove the duplicate created above (from the first loop)
+      const dupIdx = createdIds.length - 1;
+      const dupId = createdIds[dupIdx];
+      if (dupId) {
+        const idx = data.members.findIndex((m) => m.id === dupId);
+        if (idx >= 0 && data.members[idx].type === 'column') {
+          data.members.splice(idx, 1);
+          createdIds.splice(dupIdx, 1);
+        }
+      }
+      createdIds.push(clone.id);
+    }
+  }
+
+  return createdIds;
+}
+
+// ── Mirror ──
+
+function reflectPoint(point: Point2D, axisStart: Point2D, axisDir: Point2D): Point2D {
+  const v = sub2D(point, axisStart);
+  const proj = dot2D(v, axisDir);
+  return {
+    x: 2 * (axisStart.x + axisDir.x * proj) - point.x,
+    y: 2 * (axisStart.y + axisDir.y * proj) - point.y,
+  };
+}
+
+export function mirrorSelection(
+  data: ProjectData,
+  ids: string[],
+  axisStart: Point2D,
+  axisEnd: Point2D,
+  copy: boolean,
+): string[] {
+  const axisDir = normalize2D(sub2D(axisEnd, axisStart));
+  if (axisDir.x === 0 && axisDir.y === 0) return [];
+
+  const mirrorTransform = (point: Point2D): Point2D => reflectPoint(point, axisStart, axisDir);
+
+  if (!copy) {
+    applyPointTransformToSelection(data, ids, mirrorTransform);
+    return [];
+  }
+
+  // copy mode: duplicate then mirror the copies
+  const selectedIds = new Set(ids);
+  const createdIds: string[] = [];
+  const memberIdMap = new Map<string, string>();
+
+  for (const member of [...data.members]) {
+    if (!selectedIds.has(member.id)) continue;
+    const clone = deepClone(member);
+    clone.id = uuidv4();
+    transformMember(clone, mirrorTransform);
+    memberIdMap.set(member.id, clone.id);
+    data.members.push(clone);
+    createdIds.push(clone.id);
+  }
+
+  for (const annotation of [...data.annotations]) {
+    if (!selectedIds.has(annotation.id)) continue;
+    const clone = deepClone(annotation);
+    clone.id = uuidv4();
+    transformAnnotation(clone, mirrorTransform);
+    data.annotations.push(clone);
+    createdIds.push(clone.id);
+  }
+
+  for (const dimension of [...data.dimensions]) {
+    if (!selectedIds.has(dimension.id)) continue;
+    const clone = deepClone(dimension);
+    clone.id = uuidv4();
+    transformDimension(clone, mirrorTransform);
+    data.dimensions.push(clone);
+    createdIds.push(clone.id);
+  }
+
+  for (const opening of [...data.openings]) {
+    if (!selectedIds.has(opening.memberId)) continue;
+    const clonedMemberId = memberIdMap.get(opening.memberId);
+    if (!clonedMemberId) continue;
+    const clone = deepClone(opening);
+    clone.id = uuidv4();
+    clone.memberId = clonedMemberId;
+    transformOpening(clone, mirrorTransform);
+    data.openings.push(clone);
+  }
+
+  return createdIds;
+}
+
+// ── Array (rectangular) ──
+
+export function arraySelection(
+  data: ProjectData,
+  ids: string[],
+  options: ArraySelectionOptions,
+): string[] {
+  const createdIds: string[] = [];
+  const cols = Math.max(1, Math.floor(options.columns));
+  const rows = Math.max(1, Math.floor(options.rows));
+
+  for (let col = 0; col < cols; col++) {
+    for (let row = 0; row < rows; row++) {
+      if (col === 0 && row === 0) continue; // skip original position
+      const dx = col * options.colSpacing;
+      const dy = row * options.rowSpacing;
+      const newIds = duplicateSelection(data, ids, { dx, dy, count: 1 });
+      createdIds.push(...newIds);
+    }
+  }
+
+  return createdIds;
+}
+
+// ── Bounding box helpers for rectangle selection ──
+
+export interface EntityBounds {
+  id: string;
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+export function getEntityBoundsList(data: ProjectData, storyId: string | null): EntityBounds[] {
+  const result: EntityBounds[] = [];
+
+  for (const member of data.members) {
+    if (storyId && member.story !== storyId) continue;
+    const pts = getMemberPoints(member);
+    if (pts.length === 0) continue;
+    let minX = pts[0].x, minY = pts[0].y, maxX = pts[0].x, maxY = pts[0].y;
+    for (const p of pts.slice(1)) {
+      minX = Math.min(minX, p.x);
+      minY = Math.min(minY, p.y);
+      maxX = Math.max(maxX, p.x);
+      maxY = Math.max(maxY, p.y);
+    }
+    result.push({ id: member.id, minX, minY, maxX, maxY });
+  }
+
+  for (const annotation of data.annotations) {
+    if (storyId && annotation.story !== storyId) continue;
+    result.push({
+      id: annotation.id,
+      minX: annotation.x,
+      minY: annotation.y,
+      maxX: annotation.x,
+      maxY: annotation.y,
+    });
+  }
+
+  for (const dimension of data.dimensions) {
+    if (storyId && dimension.story !== storyId) continue;
+    result.push({
+      id: dimension.id,
+      minX: Math.min(dimension.start.x, dimension.end.x),
+      minY: Math.min(dimension.start.y, dimension.end.y),
+      maxX: Math.max(dimension.start.x, dimension.end.x),
+      maxY: Math.max(dimension.start.y, dimension.end.y),
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Returns IDs of entities inside (window) or intersecting (crossing) the selection rectangle.
+ */
+export function selectByRectangle(
+  entities: EntityBounds[],
+  rectMinX: number,
+  rectMinY: number,
+  rectMaxX: number,
+  rectMaxY: number,
+  mode: 'window' | 'crossing',
+): string[] {
+  const ids: string[] = [];
+  for (const e of entities) {
+    if (mode === 'window') {
+      // Fully enclosed
+      if (e.minX >= rectMinX && e.maxX <= rectMaxX && e.minY >= rectMinY && e.maxY <= rectMaxY) {
+        ids.push(e.id);
+      }
+    } else {
+      // Crossing: any overlap
+      if (e.maxX >= rectMinX && e.minX <= rectMaxX && e.maxY >= rectMinY && e.minY <= rectMaxY) {
+        ids.push(e.id);
+      }
+    }
+  }
+  return ids;
+}
+
+// ── Compute all-entity bounds (for zoom extents) ──
+
+export function getAllEntityBounds(
+  data: ProjectData,
+  storyId: string | null,
+): { minX: number; minY: number; maxX: number; maxY: number } | null {
+  const entities = getEntityBoundsList(data, storyId);
+  if (entities.length === 0) return null;
+  let minX = entities[0].minX, minY = entities[0].minY;
+  let maxX = entities[0].maxX, maxY = entities[0].maxY;
+  for (const e of entities.slice(1)) {
+    minX = Math.min(minX, e.minX);
+    minY = Math.min(minY, e.minY);
+    maxX = Math.max(maxX, e.maxX);
+    maxY = Math.max(maxY, e.maxY);
+  }
+  return { minX, minY, maxX, maxY };
 }

--- a/src/domain/structural/editTransform.ts
+++ b/src/domain/structural/editTransform.ts
@@ -67,7 +67,10 @@ function getDimensionPoints(dimension: Dimension): Point2D[] {
   return [dimension.start, dimension.end];
 }
 
-function getAnnotationPoint(annotation: Annotation): Point2D[] {
+function getAnnotationPoints(annotation: Annotation): Point2D[] {
+  if (annotation.points && annotation.points.length > 0) {
+    return annotation.points.map((p) => ({ x: p.x, y: p.y }));
+  }
   return [{ x: annotation.x, y: annotation.y }];
 }
 
@@ -83,7 +86,7 @@ function getSelectionPoints(data: ProjectData, ids: string[]): Point2D[] {
 
   for (const annotation of data.annotations) {
     if (selectedIds.has(annotation.id)) {
-      points.push(...getAnnotationPoint(annotation));
+      points.push(...getAnnotationPoints(annotation));
     }
   }
 
@@ -145,6 +148,9 @@ function transformAnnotation(annotation: Annotation, transformPoint: (point: Poi
   const next = transformPoint({ x: annotation.x, y: annotation.y });
   annotation.x = next.x;
   annotation.y = next.y;
+  if (annotation.points && annotation.points.length > 0) {
+    annotation.points = annotation.points.map((p) => transformPoint(p));
+  }
 }
 
 function transformDimension(dimension: Dimension, transformPoint: (point: Point2D) => Point2D) {
@@ -373,49 +379,36 @@ export function offsetSelection(
 
   for (const member of [...data.members]) {
     if (!selectedIds.has(member.id)) continue;
+    if (member.type === 'slab') continue;
 
-    if (member.type === 'slab') continue; // skip slabs
+    const isZeroLength =
+      member.start.x === member.end.x && member.start.y === member.end.y;
 
-    const dir = normalize2D(sub2D(
-      { x: member.end.x, y: member.end.y },
-      { x: member.start.x, y: member.start.y },
-    ));
-    const perp = perpendicular2D(dir);
-    const dx = perp.x * distance;
-    const dy = perp.y * distance;
-
-    const clone = deepClone(member);
-    clone.id = uuidv4();
-    clone.start.x += dx;
-    clone.start.y += dy;
-    clone.end.x += dx;
-    clone.end.y += dy;
-    data.members.push(clone);
-    createdIds.push(clone.id);
-  }
-
-  // Offset columns in X direction
-  for (const member of [...data.members]) {
-    if (!selectedIds.has(member.id)) continue;
-    if (member.type !== 'column') continue;
-    // Already handled above for columns (they have start/end) but the
-    // perpendicular of a zero-length vector is {0,0}. Handle as X offset:
-    if (member.start.x === member.end.x && member.start.y === member.end.y) {
+    if (isZeroLength) {
+      // Zero-length members (e.g. point columns): offset in X direction
       const clone = deepClone(member);
       clone.id = uuidv4();
       clone.start.x += distance;
       clone.end.x += distance;
       data.members.push(clone);
-      // Remove the duplicate created above (from the first loop)
-      const dupIdx = createdIds.length - 1;
-      const dupId = createdIds[dupIdx];
-      if (dupId) {
-        const idx = data.members.findIndex((m) => m.id === dupId);
-        if (idx >= 0 && data.members[idx].type === 'column') {
-          data.members.splice(idx, 1);
-          createdIds.splice(dupIdx, 1);
-        }
-      }
+      createdIds.push(clone.id);
+    } else {
+      // Normal linear members: offset perpendicular
+      const dir = normalize2D(sub2D(
+        { x: member.end.x, y: member.end.y },
+        { x: member.start.x, y: member.start.y },
+      ));
+      const perp = perpendicular2D(dir);
+      const dx = perp.x * distance;
+      const dy = perp.y * distance;
+
+      const clone = deepClone(member);
+      clone.id = uuidv4();
+      clone.start.x += dx;
+      clone.start.y += dy;
+      clone.end.x += dx;
+      clone.end.y += dy;
+      data.members.push(clone);
       createdIds.push(clone.id);
     }
   }
@@ -551,13 +544,16 @@ export function getEntityBoundsList(data: ProjectData, storyId: string | null): 
 
   for (const annotation of data.annotations) {
     if (storyId && annotation.story !== storyId) continue;
-    result.push({
-      id: annotation.id,
-      minX: annotation.x,
-      minY: annotation.y,
-      maxX: annotation.x,
-      maxY: annotation.y,
-    });
+    const aPts = getAnnotationPoints(annotation);
+    if (aPts.length === 0) continue;
+    let aMinX = aPts[0].x, aMinY = aPts[0].y, aMaxX = aPts[0].x, aMaxY = aPts[0].y;
+    for (const p of aPts.slice(1)) {
+      aMinX = Math.min(aMinX, p.x);
+      aMinY = Math.min(aMinY, p.y);
+      aMaxX = Math.max(aMaxX, p.x);
+      aMaxY = Math.max(aMaxY, p.y);
+    }
+    result.push({ id: annotation.id, minX: aMinX, minY: aMinY, maxX: aMaxX, maxY: aMaxY });
   }
 
   for (const dimension of data.dimensions) {

--- a/src/domain/structural/editTrim.ts
+++ b/src/domain/structural/editTrim.ts
@@ -1,0 +1,219 @@
+import type { Point2D } from '@/domain/geometry/types';
+import type { ProjectData, LinearMember } from './types';
+import { isLinearMember } from './types';
+
+/**
+ * Find the intersection point of two line segments (2D).
+ * Returns null if lines are parallel or intersection is outside both segments.
+ */
+export function lineLineIntersection(
+  a1: Point2D,
+  a2: Point2D,
+  b1: Point2D,
+  b2: Point2D,
+): Point2D | null {
+  const dax = a2.x - a1.x;
+  const day = a2.y - a1.y;
+  const dbx = b2.x - b1.x;
+  const dby = b2.y - b1.y;
+
+  const denom = dax * dby - day * dbx;
+  if (Math.abs(denom) < 1e-10) return null; // parallel
+
+  const t = ((b1.x - a1.x) * dby - (b1.y - a1.y) * dbx) / denom;
+  const u = ((b1.x - a1.x) * day - (b1.y - a1.y) * dax) / denom;
+
+  // For trim we use segment-line intersection (t in [0,1], u unrestricted for extend)
+  if (t < -1e-10 || t > 1 + 1e-10) return null;
+  if (u < -1e-10 || u > 1 + 1e-10) return null;
+
+  return {
+    x: a1.x + t * dax,
+    y: a1.y + t * day,
+  };
+}
+
+/**
+ * Find intersection point between a ray from a1 toward a2 and segment b1-b2.
+ * The ray parameter t is unrestricted (for extend), but u must be in [0,1].
+ */
+function raySegmentIntersection(
+  a1: Point2D,
+  a2: Point2D,
+  b1: Point2D,
+  b2: Point2D,
+): { point: Point2D; t: number } | null {
+  const dax = a2.x - a1.x;
+  const day = a2.y - a1.y;
+  const dbx = b2.x - b1.x;
+  const dby = b2.y - b1.y;
+
+  const denom = dax * dby - day * dbx;
+  if (Math.abs(denom) < 1e-10) return null;
+
+  const t = ((b1.x - a1.x) * dby - (b1.y - a1.y) * dbx) / denom;
+  const u = ((b1.x - a1.x) * day - (b1.y - a1.y) * dax) / denom;
+
+  if (u < -1e-10 || u > 1 + 1e-10) return null;
+
+  return {
+    point: { x: a1.x + t * dax, y: a1.y + t * day },
+    t,
+  };
+}
+
+function getMember2DStart(m: LinearMember): Point2D {
+  return { x: m.start.x, y: m.start.y };
+}
+
+function getMember2DEnd(m: LinearMember): Point2D {
+  return { x: m.end.x, y: m.end.y };
+}
+
+/**
+ * Trim a linear member at the nearest intersection point.
+ * `side` = 'start' keeps the start side (trims from the cut toward end).
+ * `side` = 'end' keeps the end side (trims from start toward the cut).
+ */
+export function trimMember(
+  data: ProjectData,
+  memberId: string,
+  cutPoint: Point2D,
+  side: 'start' | 'end',
+): boolean {
+  const member = data.members.find((m) => m.id === memberId);
+  if (!member || !isLinearMember(member)) return false;
+
+  const mStart = getMember2DStart(member);
+  const mEnd = getMember2DEnd(member);
+
+  // Find nearest intersection with other members
+  let closestIntersection: Point2D | null = null;
+  let closestDist = Infinity;
+
+  for (const other of data.members) {
+    if (other.id === memberId || !isLinearMember(other)) continue;
+    const oStart = getMember2DStart(other);
+    const oEnd = getMember2DEnd(other);
+    const ix = lineLineIntersection(mStart, mEnd, oStart, oEnd);
+    if (!ix) continue;
+
+    const dist = Math.hypot(ix.x - cutPoint.x, ix.y - cutPoint.y);
+    if (dist < closestDist) {
+      closestDist = dist;
+      closestIntersection = ix;
+    }
+  }
+
+  if (!closestIntersection) return false;
+
+  if (side === 'start') {
+    // Keep start side: set end to intersection
+    member.end.x = closestIntersection.x;
+    member.end.y = closestIntersection.y;
+  } else {
+    // Keep end side: set start to intersection
+    member.start.x = closestIntersection.x;
+    member.start.y = closestIntersection.y;
+  }
+
+  return true;
+}
+
+/**
+ * Extend a linear member to intersect with a target member.
+ * Extends the closest endpoint of the member toward the target.
+ */
+export function extendMember(
+  data: ProjectData,
+  memberId: string,
+  targetMemberId: string,
+): boolean {
+  const member = data.members.find((m) => m.id === memberId);
+  const target = data.members.find((m) => m.id === targetMemberId);
+  if (!member || !target || !isLinearMember(member) || !isLinearMember(target)) return false;
+
+  const mStart = getMember2DStart(member);
+  const mEnd = getMember2DEnd(member);
+  const tStart = getMember2DStart(target);
+  const tEnd = getMember2DEnd(target);
+
+  // Try extending end point
+  const endResult = raySegmentIntersection(mStart, mEnd, tStart, tEnd);
+  // Try extending start point (reverse direction)
+  const startResult = raySegmentIntersection(mEnd, mStart, tStart, tEnd);
+
+  // Pick the one that actually extends (t > 1 means beyond the segment)
+  if (endResult && endResult.t > 1) {
+    member.end.x = endResult.point.x;
+    member.end.y = endResult.point.y;
+    return true;
+  }
+
+  if (startResult && startResult.t > 1) {
+    member.start.x = startResult.point.x;
+    member.start.y = startResult.point.y;
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Fillet (clean intersection) — find where two walls meet and trim both to the intersection point.
+ * This is the MVP "clean intersection" approach.
+ */
+export function filletWalls(
+  data: ProjectData,
+  wallId1: string,
+  wallId2: string,
+  _radius: number = 0,
+): boolean {
+  const wall1 = data.members.find((m) => m.id === wallId1);
+  const wall2 = data.members.find((m) => m.id === wallId2);
+  if (!wall1 || !wall2 || !isLinearMember(wall1) || !isLinearMember(wall2)) return false;
+
+  const s1 = getMember2DStart(wall1);
+  const e1 = getMember2DEnd(wall1);
+  const s2 = getMember2DStart(wall2);
+  const e2 = getMember2DEnd(wall2);
+
+  // Find intersection using line-line (extend both lines infinitely)
+  const dax = e1.x - s1.x;
+  const day = e1.y - s1.y;
+  const dbx = e2.x - s2.x;
+  const dby = e2.y - s2.y;
+
+  const denom = dax * dby - day * dbx;
+  if (Math.abs(denom) < 1e-10) return false; // parallel
+
+  const t = ((s2.x - s1.x) * dby - (s2.y - s1.y) * dbx) / denom;
+  const intersection: Point2D = {
+    x: s1.x + t * dax,
+    y: s1.y + t * day,
+  };
+
+  // For wall1: adjust the closest endpoint to the intersection
+  const dist1Start = Math.hypot(intersection.x - s1.x, intersection.y - s1.y);
+  const dist1End = Math.hypot(intersection.x - e1.x, intersection.y - e1.y);
+  if (dist1Start < dist1End) {
+    wall1.start.x = intersection.x;
+    wall1.start.y = intersection.y;
+  } else {
+    wall1.end.x = intersection.x;
+    wall1.end.y = intersection.y;
+  }
+
+  // For wall2: adjust the closest endpoint to the intersection
+  const dist2Start = Math.hypot(intersection.x - s2.x, intersection.y - s2.y);
+  const dist2End = Math.hypot(intersection.x - e2.x, intersection.y - e2.y);
+  if (dist2Start < dist2End) {
+    wall2.start.x = intersection.x;
+    wall2.start.y = intersection.y;
+  } else {
+    wall2.end.x = intersection.x;
+    wall2.end.y = intersection.y;
+  }
+
+  return true;
+}

--- a/src/domain/structural/types.ts
+++ b/src/domain/structural/types.ts
@@ -7,6 +7,12 @@ export type TextAlign = 'left' | 'center' | 'right';
 
 // ── Project Root ─────────────────────────────────────────────
 
+export interface Group {
+  id: string;
+  name: string;
+  memberIds: string[];
+}
+
 export interface ProjectData {
   schemaVersion: string;
   project: ProjectMeta;
@@ -21,6 +27,7 @@ export interface ProjectData {
   sheets: Sheet[];
   views: View[];
   issues?: Issue[];
+  groups?: Group[];
 }
 
 export interface ProjectMeta {

--- a/src/domain/structural/types.ts
+++ b/src/domain/structural/types.ts
@@ -28,6 +28,8 @@ export interface ProjectData {
   views: View[];
   issues?: Issue[];
   groups?: Group[];
+  constructionLines?: ConstructionLine[];
+  externalRefs?: ExternalRef[];
 }
 
 export interface ProjectMeta {
@@ -153,7 +155,7 @@ export interface Opening {
 
 export interface Annotation {
   id: string;
-  type: 'text' | 'label' | 'leader';
+  type: 'text' | 'label' | 'leader' | 'spline';
   story: string;
   x: number;
   y: number;
@@ -162,6 +164,11 @@ export interface Annotation {
   rotation?: number;
   color?: string;
   textAlign?: TextAlign;
+  fontWeight?: 'normal' | 'bold';
+  fontStyle?: 'normal' | 'italic';
+  textDecoration?: 'none' | 'underline';
+  fontFamily?: string;
+  points?: Point2D[];
 }
 
 // ── Dimension ────────────────────────────────────────────────
@@ -221,6 +228,41 @@ export interface Sheet {
   viewIds: string[];
   titleBlockTemplate?: TitleBlockTemplate;
   titleBlock?: SheetTitleBlock;
+  viewports?: Viewport[];
+}
+
+// ── Construction Line ────────────────────────────────────
+
+export interface ConstructionLine {
+  id: string;
+  story: string;
+  type: 'xline' | 'ray';
+  origin: Point2D;
+  direction: Point2D;
+}
+
+// ── External Reference ──────────────────────────────────
+
+export interface ExternalRef {
+  id: string;
+  name: string;
+  data: ProjectData;
+  offsetX: number;
+  offsetY: number;
+  visible: boolean;
+}
+
+// ── Viewport ────────────────────────────────────────────
+
+export interface Viewport {
+  id: string;
+  sheetId: string;
+  viewId: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  scale: string;
 }
 
 // ── Issue ────────────────────────────────────────────────────

--- a/src/domain/templates/drawingTemplates.ts
+++ b/src/domain/templates/drawingTemplates.ts
@@ -1,0 +1,184 @@
+import { v4 as uuidv4 } from 'uuid';
+import type { ProjectData } from '@/domain/structural/types';
+
+export interface DrawingTemplate {
+  key: string;
+  labelEn: string;
+  labelJa: string;
+  create: () => ProjectData;
+}
+
+function createA1StructureTemplate(): ProjectData {
+  const storyId = '1F';
+  const viewId = `VIEW-${storyId}-PLAN`;
+  return {
+    schemaVersion: '1.0.0',
+    project: { id: uuidv4(), name: 'Structure Project', unit: 'mm' },
+    stories: [
+      { id: '1F', name: '1F', elevation: 0, height: 3000 },
+      { id: '2F', name: '2F', elevation: 3000, height: 3000 },
+    ],
+    grids: [],
+    materials: [
+      { id: 'MAT-RC-24', name: 'RC Fc24', type: 'concrete' },
+      { id: 'MAT-SD390', name: 'SD390', type: 'steel' },
+    ],
+    sections: [
+      { id: 'SEC-C600', kind: 'rc_column_rect', width: 600, depth: 600 },
+      { id: 'SEC-C700', kind: 'rc_column_rect', width: 700, depth: 700 },
+      { id: 'SEC-B300x600', kind: 'rc_beam_rect', width: 300, depth: 600 },
+      { id: 'SEC-B350x700', kind: 'rc_beam_rect', width: 350, depth: 700 },
+      { id: 'SEC-SLAB180', kind: 'rc_slab', thickness: 180 },
+      { id: 'SEC-WALL200', kind: 'rc_wall', thickness: 200 },
+    ],
+    members: [],
+    openings: [],
+    annotations: [],
+    dimensions: [],
+    views: [
+      {
+        id: viewId,
+        type: 'plan',
+        story: storyId,
+        center: { x: 4000, y: 3000 },
+        width: 14000,
+        height: 11000,
+        rotation: 0,
+      },
+    ],
+    sheets: [
+      {
+        id: 'S-001',
+        name: '1F Plan',
+        paperSize: 'A1',
+        scale: '1:100',
+        viewIds: [viewId],
+        titleBlockTemplate: 'standard',
+        titleBlock: {
+          projectName: 'Structure Project',
+          drawingTitle: '1F Plan',
+          issueDate: new Date().toISOString().slice(0, 10),
+        },
+      },
+    ],
+    issues: [],
+  };
+}
+
+function createA3DetailTemplate(): ProjectData {
+  const storyId = '1F';
+  const viewId = `VIEW-${storyId}-PLAN`;
+  return {
+    schemaVersion: '1.0.0',
+    project: { id: uuidv4(), name: 'Detail Drawing', unit: 'mm' },
+    stories: [{ id: storyId, name: storyId, elevation: 0, height: 3000 }],
+    grids: [],
+    materials: [{ id: 'MAT-RC-24', name: 'RC Fc24', type: 'concrete' }],
+    sections: [
+      { id: 'SEC-C600', kind: 'rc_column_rect', width: 600, depth: 600 },
+      { id: 'SEC-B300x600', kind: 'rc_beam_rect', width: 300, depth: 600 },
+      { id: 'SEC-SLAB180', kind: 'rc_slab', thickness: 180 },
+      { id: 'SEC-WALL200', kind: 'rc_wall', thickness: 200 },
+    ],
+    members: [],
+    openings: [],
+    annotations: [],
+    dimensions: [],
+    views: [
+      {
+        id: viewId,
+        type: 'plan',
+        story: storyId,
+        center: { x: 2000, y: 1500 },
+        width: 8000,
+        height: 6000,
+        rotation: 0,
+      },
+    ],
+    sheets: [
+      {
+        id: 'S-001',
+        name: 'Detail',
+        paperSize: 'A3',
+        scale: '1:50',
+        viewIds: [viewId],
+        titleBlockTemplate: 'compact',
+        titleBlock: {
+          projectName: 'Detail Drawing',
+          drawingTitle: 'Detail',
+          issueDate: new Date().toISOString().slice(0, 10),
+        },
+      },
+    ],
+    issues: [],
+  };
+}
+
+function createBlankA1Template(): ProjectData {
+  const storyId = '1F';
+  const viewId = `VIEW-${storyId}-PLAN`;
+  return {
+    schemaVersion: '1.0.0',
+    project: { id: uuidv4(), name: 'New Project', unit: 'mm' },
+    stories: [{ id: storyId, name: storyId, elevation: 0, height: 3000 }],
+    grids: [],
+    materials: [{ id: 'MAT-RC-24', name: 'RC Fc24', type: 'concrete' }],
+    sections: [
+      { id: 'SEC-C600', kind: 'rc_column_rect', width: 600, depth: 600 },
+      { id: 'SEC-B300x600', kind: 'rc_beam_rect', width: 300, depth: 600 },
+      { id: 'SEC-SLAB180', kind: 'rc_slab', thickness: 180 },
+      { id: 'SEC-WALL200', kind: 'rc_wall', thickness: 200 },
+    ],
+    members: [],
+    openings: [],
+    annotations: [],
+    dimensions: [],
+    views: [
+      {
+        id: viewId,
+        type: 'plan',
+        story: storyId,
+        center: { x: 4000, y: 3000 },
+        width: 14000,
+        height: 11000,
+        rotation: 0,
+      },
+    ],
+    sheets: [
+      {
+        id: 'S-001',
+        name: '1F Plan',
+        paperSize: 'A1',
+        scale: '1:100',
+        viewIds: [viewId],
+        titleBlockTemplate: 'minimal',
+        titleBlock: {
+          projectName: 'New Project',
+          drawingTitle: '1F Plan',
+        },
+      },
+    ],
+    issues: [],
+  };
+}
+
+export const drawingTemplates: DrawingTemplate[] = [
+  {
+    key: 'a1-structure',
+    labelEn: 'A1 Structure (1:100)',
+    labelJa: 'A1 構造図 (1:100)',
+    create: createA1StructureTemplate,
+  },
+  {
+    key: 'a3-detail',
+    labelEn: 'A3 Detail (1:50)',
+    labelJa: 'A3 詳細図 (1:50)',
+    create: createA3DetailTemplate,
+  },
+  {
+    key: 'blank-a1',
+    labelEn: 'Blank A1',
+    labelJa: '白紙 A1',
+    create: createBlankA1Template,
+  },
+];

--- a/src/features/editor2d/CoordinateInputDialog.tsx
+++ b/src/features/editor2d/CoordinateInputDialog.tsx
@@ -1,0 +1,115 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { useI18n } from '@/i18n';
+import type { Point2D } from '@/domain/geometry/types';
+
+interface Props {
+  lastPoint: Point2D | null;
+  onSubmit: (pos: Point2D) => void;
+}
+
+/**
+ * Parses coordinate input in three formats:
+ * - "x,y"        -> absolute coordinate
+ * - "@dx,dy"     -> relative to lastPoint
+ * - "@dist<angle" -> polar relative to lastPoint (angle in degrees)
+ */
+function parseCoordinate(input: string, lastPoint: Point2D | null): Point2D | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  if (trimmed.startsWith('@')) {
+    const rest = trimmed.slice(1);
+
+    // Polar: @distance<angle
+    const polarMatch = rest.match(/^([+-]?\d+\.?\d*)\s*<\s*([+-]?\d+\.?\d*)$/);
+    if (polarMatch) {
+      const dist = parseFloat(polarMatch[1]);
+      const angleDeg = parseFloat(polarMatch[2]);
+      if (!Number.isFinite(dist) || !Number.isFinite(angleDeg)) return null;
+      const rad = (angleDeg * Math.PI) / 180;
+      const base = lastPoint ?? { x: 0, y: 0 };
+      return {
+        x: base.x + dist * Math.cos(rad),
+        y: base.y + dist * Math.sin(rad),
+      };
+    }
+
+    // Relative: @dx,dy
+    const parts = rest.split(',');
+    if (parts.length === 2) {
+      const dx = parseFloat(parts[0]);
+      const dy = parseFloat(parts[1]);
+      if (!Number.isFinite(dx) || !Number.isFinite(dy)) return null;
+      const base = lastPoint ?? { x: 0, y: 0 };
+      return { x: base.x + dx, y: base.y + dy };
+    }
+    return null;
+  }
+
+  // Absolute: x,y
+  const parts = trimmed.split(',');
+  if (parts.length === 2) {
+    const x = parseFloat(parts[0]);
+    const y = parseFloat(parts[1]);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+    return { x, y };
+  }
+
+  return null;
+}
+
+export function CoordinateInputBar({ lastPoint, onSubmit }: Props) {
+  const [value, setValue] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { t } = useI18n();
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      const pos = parseCoordinate(value, lastPoint);
+      if (pos) {
+        onSubmit(pos);
+        setValue('');
+      }
+    },
+    [value, lastPoint, onSubmit],
+  );
+
+  // Focus when a digit or @ is pressed and this bar is visible
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.tagName === 'SELECT') return;
+      if (/^[0-9@\-.]$/.test(e.key)) {
+        inputRef.current?.focus();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        padding: '4px 12px',
+        background: 'var(--bg-panel)',
+        borderTop: '1px solid var(--border-color)',
+        fontSize: 12,
+      }}
+    >
+      <span style={{ color: 'var(--text-secondary)', whiteSpace: 'nowrap' }}>{t.coordInputLabel}:</span>
+      <input
+        ref={inputRef}
+        className="prop-input"
+        style={{ flex: 1, maxWidth: 260 }}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder={t.coordInputPlaceholder}
+      />
+    </form>
+  );
+}

--- a/src/features/editor2d/DrawPreview.tsx
+++ b/src/features/editor2d/DrawPreview.tsx
@@ -43,7 +43,7 @@ export function DrawPreview({ drawState, activeTool }: Props) {
       )}
 
       {/* Tool preview lines */}
-      {(activeTool === 'beam' || activeTool === 'wall' || activeTool === 'dimension') &&
+      {(activeTool === 'beam' || activeTool === 'wall' || activeTool === 'dimension' || activeTool === 'xline') &&
         points.length === 1 && (
           <line
             x1={points[0].x}
@@ -82,6 +82,22 @@ export function DrawPreview({ drawState, activeTool }: Props) {
           {/* Vertices */}
           {points.map((p, i) => (
             <circle key={i} cx={p.x} cy={p.y} r={80} fill="var(--color-slab)" />
+          ))}
+        </g>
+      )}
+
+      {/* Spline preview */}
+      {activeTool === 'spline' && points.length > 0 && (
+        <g>
+          <polyline
+            points={[...points, previewPos].map((p) => `${p.x},${p.y}`).join(' ')}
+            fill="none"
+            stroke="var(--color-selection)"
+            strokeWidth={20}
+            strokeDasharray="100 50"
+          />
+          {points.map((p, i) => (
+            <circle key={i} cx={p.x} cy={p.y} r={80} fill="var(--color-selection)" />
           ))}
         </g>
       )}

--- a/src/features/editor2d/Editor2D.tsx
+++ b/src/features/editor2d/Editor2D.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useRef } from 'react';
 import { useProjectStore, useEditorStore } from '@/app/store';
 import { SvgCanvas } from './SvgCanvas';
 import { GridLayer } from './layers/GridLayer';
@@ -7,13 +7,26 @@ import { DimensionLayer } from './layers/DimensionLayer';
 import { AnnotationLayer } from './layers/AnnotationLayer';
 import { DrawPreview } from './DrawPreview';
 import { useEditorInteraction } from './useEditorInteraction';
+import { CoordinateInputBar } from './CoordinateInputDialog';
+import { getAllEntityBounds, getSelectionBounds } from '@/domain/structural/editTransform';
 
 export function Editor2D() {
   const data = useProjectStore((s) => s.data);
   const { activeStory, selectedIds, layerVisibility, activeTool, setActiveTool } =
     useEditorStore();
-  const { drawState, handleClick, handleDoubleClick, handleMouseMove, resetDrawing } =
-    useEditorInteraction();
+  const {
+    drawState,
+    rectSelect,
+    handleClick,
+    handleDoubleClick,
+    handleMouseMove,
+    handleMouseDown,
+    handleMouseUp,
+    injectCoordinate,
+    resetDrawing,
+  } = useEditorInteraction();
+
+  const containerRef = useRef<HTMLDivElement>(null);
 
   // ESC to cancel drawing or deselect
   const handleKeyDown = useCallback(
@@ -27,11 +40,45 @@ export function Editor2D() {
         }
       }
       if (e.key === 'Delete' || e.key === 'Backspace') {
+        const target = e.target as HTMLElement;
+        if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') return;
         const ids = useEditorStore.getState().selectedIds;
         for (const id of ids) {
           useProjectStore.getState().deleteById(id);
         }
         useEditorStore.getState().setSelectedIds([]);
+      }
+
+      // Z = Zoom extents, Shift+Z = Zoom to selection
+      if ((e.key === 'z' || e.key === 'Z') && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        const target = e.target as HTMLElement;
+        if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.tagName === 'SELECT') return;
+
+        const projectData = useProjectStore.getState().data;
+        const editorState = useEditorStore.getState();
+        if (!projectData) return;
+
+        const el = containerRef.current;
+        if (!el) return;
+        const vw = el.clientWidth;
+        const vh = el.clientHeight;
+
+        if (e.shiftKey) {
+          // Zoom to selection
+          if (editorState.selectedIds.length === 0) return;
+          const bounds = getSelectionBounds(projectData, editorState.selectedIds);
+          if (!bounds) return;
+          editorState.zoomToFit(
+            { minX: bounds.min.x, minY: bounds.min.y, maxX: bounds.max.x, maxY: bounds.max.y },
+            vw,
+            vh,
+          );
+        } else {
+          // Zoom extents
+          const allBounds = getAllEntityBounds(projectData, editorState.activeStory);
+          if (!allBounds) return;
+          editorState.zoomToFit(allBounds, vw, vh);
+        }
       }
     },
     [drawState.points.length, resetDrawing, setActiveTool],
@@ -56,27 +103,67 @@ export function Editor2D() {
 
   const isVisible = (layer: string) => layerVisibility[layer] !== false;
 
+  // Determine if a drawing tool is active (for coord input bar)
+  const isDrawingTool = activeTool !== 'select' && activeTool !== 'pan';
+
+  // Last point for coordinate input (relative coordinates)
+  const lastPoint = drawState.points.length > 0 ? drawState.points[drawState.points.length - 1] : null;
+
+  // Selection rectangle overlay (in screen coordinates)
+  let selectionRectOverlay: React.ReactNode = null;
+  if (rectSelect.start && rectSelect.end) {
+    const s = rectSelect.start;
+    const e = rectSelect.end;
+    const isWindow = e.x >= s.x; // left-to-right = window
+    const minX = Math.min(s.x, e.x);
+    const minY = Math.min(s.y, e.y);
+    const w = Math.abs(e.x - s.x);
+    const h = Math.abs(e.y - s.y);
+    selectionRectOverlay = (
+      <rect
+        x={minX}
+        y={minY}
+        width={w}
+        height={h}
+        fill={isWindow ? 'rgba(0,120,255,0.08)' : 'rgba(0,200,60,0.08)'}
+        stroke={isWindow ? '#0078ff' : '#00c83c'}
+        strokeWidth={40}
+        strokeDasharray={isWindow ? 'none' : '200 100'}
+      />
+    );
+  }
+
   return (
-    <SvgCanvas
-      onWorldClick={handleClick}
-      onWorldMouseMove={handleMouseMove}
-      onWorldDoubleClick={handleDoubleClick}
-    >
-      {isVisible('grid') && <GridLayer grids={data.grids} extent={10000} />}
-      {isVisible('member-slab') || isVisible('member-wall') || isVisible('member-beam') || isVisible('member-column') ? (
-        <MemberLayer
-          members={filteredMembers.filter((m) => isVisible(`member-${m.type}`))}
-          sections={data.sections}
-          selectedIds={selectedIds}
-        />
-      ) : null}
-      {isVisible('dimension') && (
-        <DimensionLayer dimensions={filteredDimensions} selectedIds={selectedIds} />
+    <div ref={containerRef} style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <div style={{ flex: 1, overflow: 'hidden' }}>
+        <SvgCanvas
+          onWorldClick={handleClick}
+          onWorldMouseMove={handleMouseMove}
+          onWorldDoubleClick={handleDoubleClick}
+          onWorldMouseDown={handleMouseDown}
+          onWorldMouseUp={handleMouseUp}
+        >
+          {isVisible('grid') && <GridLayer grids={data.grids} extent={10000} />}
+          {isVisible('member-slab') || isVisible('member-wall') || isVisible('member-beam') || isVisible('member-column') ? (
+            <MemberLayer
+              members={filteredMembers.filter((m) => isVisible(`member-${m.type}`))}
+              sections={data.sections}
+              selectedIds={selectedIds}
+            />
+          ) : null}
+          {isVisible('dimension') && (
+            <DimensionLayer dimensions={filteredDimensions} selectedIds={selectedIds} />
+          )}
+          {isVisible('annotation') && (
+            <AnnotationLayer annotations={filteredAnnotations} selectedIds={selectedIds} />
+          )}
+          <DrawPreview drawState={drawState} activeTool={activeTool} />
+          {selectionRectOverlay}
+        </SvgCanvas>
+      </div>
+      {isDrawingTool && (
+        <CoordinateInputBar lastPoint={lastPoint} onSubmit={injectCoordinate} />
       )}
-      {isVisible('annotation') && (
-        <AnnotationLayer annotations={filteredAnnotations} selectedIds={selectedIds} />
-      )}
-      <DrawPreview drawState={drawState} activeTool={activeTool} />
-    </SvgCanvas>
+    </div>
   );
 }

--- a/src/features/editor2d/Editor2D.tsx
+++ b/src/features/editor2d/Editor2D.tsx
@@ -100,6 +100,9 @@ export function Editor2D() {
   const filteredDimensions = data.dimensions.filter(
     (d) => !activeStory || d.story === activeStory,
   );
+  const filteredConstructionLines = (data.constructionLines ?? []).filter(
+    (cl) => !activeStory || cl.story === activeStory,
+  );
 
   const isVisible = (layer: string) => layerVisibility[layer] !== false;
 
@@ -157,6 +160,64 @@ export function Editor2D() {
           {isVisible('annotation') && (
             <AnnotationLayer annotations={filteredAnnotations} selectedIds={selectedIds} />
           )}
+          {isVisible('construction') && filteredConstructionLines.length > 0 && (
+            <g className="layer-construction">
+              {filteredConstructionLines.map((cl) => {
+                // Extend construction line to very large bounds
+                const ext = 500000;
+                if (cl.type === 'xline') {
+                  return (
+                    <line
+                      key={cl.id}
+                      data-id={cl.id}
+                      x1={cl.origin.x - cl.direction.x * ext}
+                      y1={cl.origin.y - cl.direction.y * ext}
+                      x2={cl.origin.x + cl.direction.x * ext}
+                      y2={cl.origin.y + cl.direction.y * ext}
+                      stroke="var(--color-annotation)"
+                      strokeWidth={10}
+                      strokeDasharray="80 60"
+                      opacity={0.5}
+                    />
+                  );
+                }
+                // ray: origin to +direction
+                return (
+                  <line
+                    key={cl.id}
+                    data-id={cl.id}
+                    x1={cl.origin.x}
+                    y1={cl.origin.y}
+                    x2={cl.origin.x + cl.direction.x * ext}
+                    y2={cl.origin.y + cl.direction.y * ext}
+                    stroke="var(--color-annotation)"
+                    strokeWidth={10}
+                    strokeDasharray="80 60"
+                    opacity={0.5}
+                  />
+                );
+              })}
+            </g>
+          )}
+          {/* External reference overlay */}
+          {data.externalRefs?.map((ref) => {
+            if (!ref.visible) return null;
+            const refMembers = ref.data.members;
+            return (
+              <g key={ref.id} transform={`translate(${ref.offsetX}, ${ref.offsetY})`} opacity={0.35} style={{ pointerEvents: 'none' }}>
+                {refMembers.map((m) => {
+                  if (m.type === 'slab') {
+                    const pts = m.polygon.map((p) => `${p.x},${p.y}`).join(' ');
+                    return <polygon key={m.id} points={pts} fill="none" stroke="#999" strokeWidth={15} />;
+                  }
+                  if ('start' in m && 'end' in m) {
+                    return <line key={m.id} x1={m.start.x} y1={m.start.y} x2={m.end.x} y2={m.end.y} stroke="#999" strokeWidth={15} />;
+                  }
+                  return null;
+                })}
+              </g>
+            );
+          })}
           <DrawPreview drawState={drawState} activeTool={activeTool} />
           {selectionRectOverlay}
         </SvgCanvas>

--- a/src/features/editor2d/TransformDialog.tsx
+++ b/src/features/editor2d/TransformDialog.tsx
@@ -7,7 +7,7 @@ interface Props {
   onClose: () => void;
 }
 
-type TransformMode = 'move' | 'copy' | 'scale' | 'stretch';
+type TransformMode = 'move' | 'copy' | 'scale' | 'stretch' | 'offset' | 'mirror' | 'array';
 
 function formatValue(value: number) {
   return Number.isInteger(value) ? String(value) : value.toFixed(2);
@@ -69,14 +69,34 @@ function SelectField({
   );
 }
 
+function CheckboxField({
+  label,
+  checked,
+  onChange,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}) {
+  return (
+    <label style={{ display: 'flex', gap: 6, alignItems: 'center', fontSize: 12, color: 'var(--text-secondary)' }}>
+      <input type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} />
+      {label}
+    </label>
+  );
+}
+
 export function TransformDialog({ onClose }: Props) {
   const data = useProjectStore((state) => state.data);
   const translateEntities = useProjectStore((state) => state.translateEntities);
   const duplicateEntities = useProjectStore((state) => state.duplicateEntities);
   const scaleEntities = useProjectStore((state) => state.scaleEntities);
   const stretchEntities = useProjectStore((state) => state.stretchEntities);
+  const offsetEntities = useProjectStore((state) => state.offsetEntities);
+  const mirrorEntities = useProjectStore((state) => state.mirrorEntities);
+  const arrayEntities = useProjectStore((state) => state.arrayEntities);
   const { selectedIds, setSelectedIds } = useEditorStore();
-  const { locale } = useI18n();
+  const { t, locale } = useI18n();
   const bounds = data && selectedIds.length > 0 ? getSelectionBounds(data, selectedIds) : null;
   const defaultOriginX = bounds ? formatValue(bounds.center.x) : '0';
   const defaultOriginY = bounds ? formatValue(bounds.center.y) : '0';
@@ -94,6 +114,17 @@ export function TransformDialog({ onClose }: Props) {
   const [targetHeight, setTargetHeight] = useState(defaultTargetHeight);
   const [anchorX, setAnchorX] = useState<TransformAnchor>('center');
   const [anchorY, setAnchorY] = useState<TransformAnchor>('center');
+  // Offset
+  const [offsetDistance, setOffsetDistance] = useState('1000');
+  // Mirror
+  const [mirrorAxis, setMirrorAxis] = useState<'horizontal' | 'vertical' | 'custom'>('horizontal');
+  const [mirrorAngle, setMirrorAngle] = useState('0');
+  const [mirrorCopy, setMirrorCopy] = useState(true);
+  // Array
+  const [arrayRows, setArrayRows] = useState('2');
+  const [arrayCols, setArrayCols] = useState('2');
+  const [arrayRowSpacing, setArrayRowSpacing] = useState('3000');
+  const [arrayColSpacing, setArrayColSpacing] = useState('3000');
 
   if (!data || selectedIds.length === 0 || !bounds) return null;
 
@@ -180,6 +211,12 @@ export function TransformDialog({ onClose }: Props) {
     { value: 'max', label: labels.anchorMaxY },
   ];
 
+  const mirrorAxisOptions = [
+    { value: 'horizontal', label: t.transformAxisHorizontal },
+    { value: 'vertical', label: t.transformAxisVertical },
+    { value: 'custom', label: t.transformAxisCustom },
+  ];
+
   const handleApply = () => {
     if (mode === 'move') {
       const nextDx = parseNumber(dx);
@@ -236,32 +273,116 @@ export function TransformDialog({ onClose }: Props) {
       return;
     }
 
-    const nextTargetWidth = parseNumber(targetWidth);
-    const nextTargetHeight = parseNumber(targetHeight);
-    if (nextTargetWidth === null || nextTargetHeight === null) {
-      alert(labels.invalidNumber);
+    if (mode === 'stretch') {
+      const nextTargetWidth = parseNumber(targetWidth);
+      const nextTargetHeight = parseNumber(targetHeight);
+      if (nextTargetWidth === null || nextTargetHeight === null) {
+        alert(labels.invalidNumber);
+        return;
+      }
+      if (nextTargetWidth < 0 || nextTargetHeight < 0) {
+        alert(labels.invalidStretch);
+        return;
+      }
+      if (bounds.width === 0 && nextTargetWidth !== 0) {
+        alert(labels.lockedWidth);
+        return;
+      }
+      if (bounds.height === 0 && nextTargetHeight !== 0) {
+        alert(labels.lockedHeight);
+        return;
+      }
+      stretchEntities(selectedIds, {
+        targetWidth: nextTargetWidth,
+        targetHeight: nextTargetHeight,
+        anchorX,
+        anchorY,
+      });
+      onClose();
       return;
     }
-    if (nextTargetWidth < 0 || nextTargetHeight < 0) {
-      alert(labels.invalidStretch);
+
+    if (mode === 'offset') {
+      const dist = parseNumber(offsetDistance);
+      if (dist === null) {
+        alert(labels.invalidNumber);
+        return;
+      }
+      const createdIds = offsetEntities(selectedIds, dist);
+      if (createdIds.length > 0) {
+        setSelectedIds(createdIds);
+      }
+      onClose();
       return;
     }
-    if (bounds.width === 0 && nextTargetWidth !== 0) {
-      alert(labels.lockedWidth);
+
+    if (mode === 'mirror') {
+      let axisStart = bounds.center;
+      let axisEnd = { x: bounds.center.x + 1, y: bounds.center.y };
+      if (mirrorAxis === 'horizontal') {
+        // Mirror across horizontal axis (Y stays same, X flips) -> axis is horizontal line
+        axisStart = { x: bounds.center.x, y: bounds.center.y };
+        axisEnd = { x: bounds.center.x + 1, y: bounds.center.y };
+      } else if (mirrorAxis === 'vertical') {
+        axisStart = { x: bounds.center.x, y: bounds.center.y };
+        axisEnd = { x: bounds.center.x, y: bounds.center.y + 1 };
+      } else {
+        const angle = parseNumber(mirrorAngle);
+        if (angle === null) {
+          alert(labels.invalidNumber);
+          return;
+        }
+        const rad = (angle * Math.PI) / 180;
+        axisStart = bounds.center;
+        axisEnd = {
+          x: bounds.center.x + Math.cos(rad),
+          y: bounds.center.y + Math.sin(rad),
+        };
+      }
+      const createdIds = mirrorEntities(selectedIds, axisStart, axisEnd, mirrorCopy);
+      if (createdIds.length > 0) {
+        setSelectedIds(createdIds);
+      }
+      onClose();
       return;
     }
-    if (bounds.height === 0 && nextTargetHeight !== 0) {
-      alert(labels.lockedHeight);
+
+    if (mode === 'array') {
+      const rows = parseCount(arrayRows);
+      const cols = parseCount(arrayCols);
+      const rowSpacing = parseNumber(arrayRowSpacing);
+      const colSpacing = parseNumber(arrayColSpacing);
+      if (rows === null || cols === null) {
+        alert(labels.invalidCount);
+        return;
+      }
+      if (rowSpacing === null || colSpacing === null) {
+        alert(labels.invalidNumber);
+        return;
+      }
+      const createdIds = arrayEntities(selectedIds, {
+        rows,
+        columns: cols,
+        rowSpacing,
+        colSpacing,
+      });
+      if (createdIds.length > 0) {
+        setSelectedIds(createdIds);
+      }
+      onClose();
       return;
     }
-    stretchEntities(selectedIds, {
-      targetWidth: nextTargetWidth,
-      targetHeight: nextTargetHeight,
-      anchorX,
-      anchorY,
-    });
-    onClose();
   };
+
+  const allModes: Array<[TransformMode, string]> = [
+    ['move', labels.modeMove],
+    ['copy', labels.modeCopy],
+    ['scale', labels.modeScale],
+    ['stretch', labels.modeStretch],
+    ['offset', t.transformOffset],
+    ['mirror', t.transformMirror],
+    ['array', t.transformArray],
+  ];
 
   return (
     <div
@@ -298,12 +419,7 @@ export function TransformDialog({ onClose }: Props) {
         </div>
 
         <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 16 }}>
-          {([
-            ['move', labels.modeMove],
-            ['copy', labels.modeCopy],
-            ['scale', labels.modeScale],
-            ['stretch', labels.modeStretch],
-          ] as Array<[TransformMode, string]>).map(([value, label]) => (
+          {allModes.map(([value, label]) => (
             <button
               key={value}
               className={`toolbar-btn ${mode === value ? 'active' : ''}`}
@@ -356,6 +472,40 @@ export function TransformDialog({ onClose }: Props) {
               <NumberField label={labels.targetHeight} value={targetHeight} onChange={setTargetHeight} />
               <SelectField label={labels.anchorX} value={anchorX} options={anchorXOptions} onChange={(value) => setAnchorX(value as TransformAnchor)} />
               <SelectField label={labels.anchorY} value={anchorY} options={anchorYOptions} onChange={(value) => setAnchorY(value as TransformAnchor)} />
+            </div>
+          </div>
+        )}
+
+        {mode === 'offset' && (
+          <div style={{ display: 'grid', gap: 12 }}>
+            <SectionTitle>{t.transformOffset}</SectionTitle>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr', gap: 12 }}>
+              <NumberField label={t.transformOffsetDistance} value={offsetDistance} onChange={setOffsetDistance} />
+            </div>
+          </div>
+        )}
+
+        {mode === 'mirror' && (
+          <div style={{ display: 'grid', gap: 12 }}>
+            <SectionTitle>{t.transformMirror}</SectionTitle>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+              <SelectField label={t.transformMirrorAxis} value={mirrorAxis} options={mirrorAxisOptions} onChange={(v) => setMirrorAxis(v as 'horizontal' | 'vertical' | 'custom')} />
+              {mirrorAxis === 'custom' && (
+                <NumberField label={t.transformAxisAngle} value={mirrorAngle} onChange={setMirrorAngle} />
+              )}
+            </div>
+            <CheckboxField label={t.transformMirrorCopy} checked={mirrorCopy} onChange={setMirrorCopy} />
+          </div>
+        )}
+
+        {mode === 'array' && (
+          <div style={{ display: 'grid', gap: 12 }}>
+            <SectionTitle>{t.transformArray}</SectionTitle>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+              <NumberField label={t.transformArrayColumns} value={arrayCols} onChange={setArrayCols} />
+              <NumberField label={t.transformArrayRows} value={arrayRows} onChange={setArrayRows} />
+              <NumberField label={t.transformArrayColSpacing} value={arrayColSpacing} onChange={setArrayColSpacing} />
+              <NumberField label={t.transformArrayRowSpacing} value={arrayRowSpacing} onChange={setArrayRowSpacing} />
             </div>
           </div>
         )}

--- a/src/features/editor2d/layers/AnnotationLayer.tsx
+++ b/src/features/editor2d/layers/AnnotationLayer.tsx
@@ -1,4 +1,5 @@
 import type { Annotation, TextAlign } from '@/domain/structural/types';
+import type { Point2D } from '@/domain/geometry/types';
 
 interface Props {
   annotations: Annotation[];
@@ -13,12 +14,54 @@ function textAlignToAnchor(align: TextAlign | undefined): 'start' | 'middle' | '
   }
 }
 
+/** Convert Catmull-Rom control points to a smooth SVG cubic bezier path */
+function catmullRomToPath(pts: Point2D[]): string {
+  if (pts.length < 2) return '';
+  if (pts.length === 2) {
+    return `M ${pts[0].x},${pts[0].y} L ${pts[1].x},${pts[1].y}`;
+  }
+
+  const d: string[] = [`M ${pts[0].x},${pts[0].y}`];
+  for (let i = 0; i < pts.length - 1; i++) {
+    const p0 = pts[Math.max(0, i - 1)];
+    const p1 = pts[i];
+    const p2 = pts[i + 1];
+    const p3 = pts[Math.min(pts.length - 1, i + 2)];
+
+    // Catmull-Rom to cubic bezier conversion
+    const cp1x = p1.x + (p2.x - p0.x) / 6;
+    const cp1y = p1.y + (p2.y - p0.y) / 6;
+    const cp2x = p2.x - (p3.x - p1.x) / 6;
+    const cp2y = p2.y - (p3.y - p1.y) / 6;
+
+    d.push(`C ${cp1x},${cp1y} ${cp2x},${cp2y} ${p2.x},${p2.y}`);
+  }
+  return d.join(' ');
+}
+
 export function AnnotationLayer({ annotations, selectedIds }: Props) {
   return (
     <g className="layer-annotation">
       {annotations.map((a) => {
         const selected = selectedIds.includes(a.id);
         const color = selected ? 'var(--color-selection)' : (a.color ?? 'var(--color-annotation)');
+
+        // Spline rendering
+        if (a.type === 'spline' && a.points && a.points.length >= 2) {
+          const pathD = catmullRomToPath(a.points);
+          return (
+            <path
+              key={a.id}
+              data-id={a.id}
+              d={pathD}
+              fill="none"
+              stroke={color}
+              strokeWidth={selected ? 30 : 20}
+              style={{ cursor: 'pointer' }}
+            />
+          );
+        }
+
         const fontSize = a.fontSize ?? 300;
         const anchor = textAlignToAnchor(a.textAlign);
         const rotation = a.rotation ?? 0;
@@ -29,6 +72,12 @@ export function AnnotationLayer({ annotations, selectedIds }: Props) {
         const rotateTransform = rotation !== 0 ? ` rotate(${-rotation}, ${a.x}, ${-a.y})` : '';
         const transform = baseTransform + rotateTransform;
 
+        // Text formatting
+        const fontWeight = selected ? 'bold' : (a.fontWeight ?? 'normal');
+        const fontStyle = a.fontStyle ?? 'normal';
+        const textDecoration = a.textDecoration ?? 'none';
+        const fontFamily = a.fontFamily ?? undefined;
+
         return (
           <text
             key={a.id}
@@ -37,7 +86,10 @@ export function AnnotationLayer({ annotations, selectedIds }: Props) {
             y={a.y}
             fontSize={fontSize}
             fill={color}
-            fontWeight={selected ? 'bold' : 'normal'}
+            fontWeight={fontWeight}
+            fontStyle={fontStyle}
+            textDecoration={textDecoration}
+            fontFamily={fontFamily}
             textAnchor={anchor}
             transform={transform}
             style={{ cursor: 'pointer' }}

--- a/src/features/editor2d/useEditorInteraction.ts
+++ b/src/features/editor2d/useEditorInteraction.ts
@@ -8,6 +8,7 @@ import type { Point2D } from '@/domain/geometry/types';
 import { findSnap, buildSnapCandidatesFromMembers } from '@/domain/geometry/snap';
 import type { SnapResult } from '@/domain/geometry/snap';
 import { snapPointToGrid } from '@/domain/geometry/transform';
+import { getEntityBoundsList, selectByRectangle } from '@/domain/structural/editTransform';
 
 export interface DrawState {
   /** Points collected so far for multi-click tools */
@@ -18,11 +19,23 @@ export interface DrawState {
   snapResult: SnapResult | null;
 }
 
+export interface RectSelectState {
+  /** Start point in world coords */
+  start: Point2D | null;
+  /** Current end point in world coords */
+  end: Point2D | null;
+}
+
 export function useEditorInteraction() {
   const [drawState, setDrawState] = useState<DrawState>({
     points: [],
     previewPos: null,
     snapResult: null,
+  });
+
+  const [rectSelect, setRectSelect] = useState<RectSelectState>({
+    start: null,
+    end: null,
   });
 
   const getSnapPos = useCallback(
@@ -272,8 +285,70 @@ export function useEditorInteraction() {
         previewPos: pos,
         snapResult: snap,
       }));
+      // Update rect select end if dragging
+      setRectSelect((prev) => {
+        if (prev.start) {
+          return { ...prev, end: worldPos };
+        }
+        return prev;
+      });
     },
     [getSnapPos],
+  );
+
+  const handleMouseDown = useCallback(
+    (worldPos: Point2D, e: React.MouseEvent) => {
+      const { activeTool } = useEditorStore.getState();
+      if (activeTool === 'select' && e.button === 0) {
+        // Start rect select only if clicking on empty area (not on an entity)
+        const target = (e.target as SVGElement).closest('[data-id]');
+        if (!target) {
+          setRectSelect({ start: worldPos, end: worldPos });
+        }
+      }
+    },
+    [],
+  );
+
+  const handleMouseUp = useCallback(
+    (_worldPos: Point2D, _e: React.MouseEvent) => {
+      setRectSelect((prev) => {
+        if (prev.start && prev.end) {
+          const minX = Math.min(prev.start.x, prev.end.x);
+          const maxX = Math.max(prev.start.x, prev.end.x);
+          const minY = Math.min(prev.start.y, prev.end.y);
+          const maxY = Math.max(prev.start.y, prev.end.y);
+          const width = maxX - minX;
+          const height = maxY - minY;
+
+          // Only process if drag was big enough (avoid accidental micro-drags)
+          if (width > 50 || height > 50) {
+            const data = useProjectStore.getState().data;
+            const { activeStory } = useEditorStore.getState();
+            if (data) {
+              const entities = getEntityBoundsList(data, activeStory);
+              // left-to-right = window, right-to-left = crossing
+              const mode = prev.end.x >= prev.start.x ? 'window' : 'crossing';
+              const ids = selectByRectangle(entities, minX, minY, maxX, maxY, mode);
+              useEditorStore.getState().setSelectedIds(ids);
+            }
+          }
+        }
+        return { start: null, end: null };
+      });
+    },
+    [],
+  );
+
+  /** Inject a coordinate point as if user clicked at that position. */
+  const injectCoordinate = useCallback(
+    (pos: Point2D) => {
+      const { activeTool } = useEditorStore.getState();
+      if (activeTool !== 'select' && activeTool !== 'pan') {
+        handleDrawingClick(activeTool, pos);
+      }
+    },
+    [handleDrawingClick],
   );
 
   const resetDrawing = useCallback(() => {
@@ -282,9 +357,13 @@ export function useEditorInteraction() {
 
   return {
     drawState,
+    rectSelect,
     handleClick,
     handleDoubleClick,
     handleMouseMove,
+    handleMouseDown,
+    handleMouseUp,
+    injectCoordinate,
     resetDrawing,
   };
 }

--- a/src/features/editor2d/useEditorInteraction.ts
+++ b/src/features/editor2d/useEditorInteraction.ts
@@ -232,11 +232,61 @@ export function useEditorInteraction() {
           if (dimension && layerLocked['dimension']) return;
         }
 
+        // Group selection: if member belongs to a group, select all group members
+        if (data) {
+          const memberForGroup = data.members.find((m) => m.id === id);
+          if (memberForGroup && data.groups && !(e.shiftKey || e.ctrlKey || e.metaKey)) {
+            const group = data.groups.find((g) => g.memberIds.includes(id));
+            if (group) {
+              setSelectedIds(group.memberIds.filter((mid) => data.members.some((m) => m.id === mid)));
+              return;
+            }
+          }
+        }
+
         if (e.shiftKey || e.ctrlKey || e.metaKey) {
           toggleSelection(id);
         } else {
           setSelectedIds([id]);
         }
+        return;
+      }
+
+      // Trim tool: click on a member to trim it at nearest intersection
+      if (activeTool === 'trim') {
+        const target = (e.target as SVGElement).closest('[data-id]');
+        if (!target) return;
+        const id = target.getAttribute('data-id')!;
+        const store = useProjectStore.getState();
+        if (!store.data) return;
+        const member = store.data.members.find((m) => m.id === id);
+        if (!member || member.type === 'slab') return;
+        // Determine which side to keep based on click proximity to start/end
+        const distToStart = Math.hypot(worldPos.x - member.start.x, worldPos.y - member.start.y);
+        const distToEnd = Math.hypot(worldPos.x - member.end.x, worldPos.y - member.end.y);
+        const side = distToEnd < distToStart ? 'start' : 'end';
+        store.trimMember(id, worldPos, side);
+        return;
+      }
+
+      // Extend tool: first click selects member, second click selects target
+      if (activeTool === 'extend') {
+        const target = (e.target as SVGElement).closest('[data-id]');
+        if (!target) return;
+        const id = target.getAttribute('data-id')!;
+        setDrawState((prev) => {
+          if (prev.points.length === 0) {
+            // First click: store the member to extend (abuse points array for state)
+            return { ...prev, points: [{ x: 0, y: 0 }], previewPos: null, snapResult: null, _extendMemberId: id } as DrawState & { _extendMemberId: string };
+          } else {
+            // Second click: extend the stored member to the clicked target
+            const storedId = (prev as DrawState & { _extendMemberId?: string })._extendMemberId;
+            if (storedId) {
+              useProjectStore.getState().extendMember(storedId, id);
+            }
+            return { points: [], previewPos: null, snapResult: null };
+          }
+        });
         return;
       }
 

--- a/src/features/editor2d/useEditorInteraction.ts
+++ b/src/features/editor2d/useEditorInteraction.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { useProjectStore, useEditorStore } from '@/app/store';
 import type { EditorTool } from '@/app/store';
 import { useI18n } from '@/i18n';
-import type { Annotation, Dimension, ColumnMember, BeamMember, WallMember, SlabMember } from '@/domain/structural/types';
+import type { Annotation, Dimension, ColumnMember, BeamMember, WallMember, SlabMember, ConstructionLine } from '@/domain/structural/types';
 import type { Point2D } from '@/domain/geometry/types';
 import { findSnap, buildSnapCandidatesFromMembers } from '@/domain/geometry/snap';
 import type { SnapResult } from '@/domain/geometry/snap';
@@ -204,6 +204,38 @@ export function useEditorInteraction() {
           store.addAnnotation(ann);
           break;
         }
+
+        case 'xline': {
+          setDrawState((prev) => {
+            const pts = [...prev.points, pos];
+            if (pts.length >= 2) {
+              const dx = pts[1].x - pts[0].x;
+              const dy = pts[1].y - pts[0].y;
+              const len = Math.sqrt(dx * dx + dy * dy);
+              if (len > 0) {
+                const cl: ConstructionLine = {
+                  id: uuidv4(),
+                  story: activeStory,
+                  type: 'xline',
+                  origin: { x: pts[0].x, y: pts[0].y },
+                  direction: { x: dx / len, y: dy / len },
+                };
+                store.addConstructionLine(cl);
+              }
+              return { points: [], previewPos: null, snapResult: null };
+            }
+            return { ...prev, points: pts };
+          });
+          break;
+        }
+
+        case 'spline': {
+          setDrawState((prev) => {
+            const pts = [...prev.points, pos];
+            return { ...prev, points: pts };
+          });
+          break;
+        }
       }
     },
     [],
@@ -320,6 +352,28 @@ export function useEditorInteraction() {
             level: story.elevation + story.height,
           };
           store.addMember(member);
+          return { points: [], previewPos: null, snapResult: null };
+        });
+      }
+
+      // Close spline on double-click
+      if (activeTool === 'spline') {
+        setDrawState((prev) => {
+          if (prev.points.length < 2) return prev;
+          const store = useProjectStore.getState();
+          const { activeStory } = useEditorStore.getState();
+          if (!store.data || !activeStory) return prev;
+
+          const ann: Annotation = {
+            id: uuidv4(),
+            type: 'spline',
+            story: activeStory,
+            x: prev.points[0].x,
+            y: prev.points[0].y,
+            text: '',
+            points: prev.points.map((p) => ({ x: p.x, y: p.y })),
+          };
+          store.addAnnotation(ann);
           return { points: [], previewPos: null, snapResult: null };
         });
       }

--- a/src/features/project/MasterDataDialog.tsx
+++ b/src/features/project/MasterDataDialog.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import { useEditorStore, useProjectStore } from '@/app/store';
 import { useI18n } from '@/i18n';
-import type { Material, Section, Sheet, Story, TitleBlockTemplate } from '@/domain/structural/types';
+import type { Material, Section, Sheet, Story, TitleBlockTemplate, Viewport } from '@/domain/structural/types';
 
 interface Props {
   onClose: () => void;
@@ -46,6 +46,12 @@ interface Labels {
   noSheets: string;
   addMaterial: string;
   addSection: string;
+  viewports: string;
+  addViewport: string;
+  removeViewport: string;
+  viewId: string;
+  x: string;
+  y: string;
 }
 
 const TEMPLATE_OPTIONS: TitleBlockTemplate[] = ['standard', 'compact', 'minimal'];
@@ -91,6 +97,12 @@ function getLabels(locale: 'ja' | 'en'): Labels {
       noSheets: 'シートがありません。アクティブ階から追加してください。',
       addMaterial: '材料追加',
       addSection: '断面追加',
+      viewports: 'ビューポート',
+      addViewport: 'ビューポート追加',
+      removeViewport: '削除',
+      viewId: 'ビューID',
+      x: 'X',
+      y: 'Y',
     };
   }
 
@@ -130,6 +142,12 @@ function getLabels(locale: 'ja' | 'en'): Labels {
     noSheets: 'No sheets yet. Add one from the active story.',
     addMaterial: 'Add Material',
     addSection: 'Add Section',
+    viewports: 'Viewports',
+    addViewport: 'Add Viewport',
+    removeViewport: 'Remove',
+    viewId: 'View ID',
+    x: 'X',
+    y: 'Y',
   };
 }
 
@@ -177,6 +195,9 @@ export function MasterDataDialog({ onClose }: Props) {
     updateSection,
     deleteSection,
     updateSheet,
+    addViewport,
+    removeViewport,
+    updateViewport,
   } = useProjectStore();
   const { activeStory, setActiveStory } = useEditorStore();
   const { locale } = useI18n();
@@ -411,6 +432,50 @@ export function MasterDataDialog({ onClose }: Props) {
                       value={sheet.titleBlock?.note ?? ''}
                       onChange={(value) => updateSheetTitleBlock(sheet, { note: value })}
                     />
+                  </div>
+
+                  {/* Viewports */}
+                  <div style={{ borderTop: '1px dashed var(--border-color)', paddingTop: 8, marginTop: 4 }}>
+                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 6 }}>
+                      <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-secondary)' }}>{labels.viewports}</span>
+                      <button
+                        className="toolbar-btn"
+                        style={{ fontSize: 11 }}
+                        onClick={() => {
+                          const firstViewId = data.views[0]?.id ?? '';
+                          if (!firstViewId) return;
+                          const vp: Viewport = {
+                            id: `VP-${sheet.id}-${(sheet.viewports?.length ?? 0) + 1}`,
+                            sheetId: sheet.id,
+                            viewId: firstViewId,
+                            x: 30,
+                            y: 30,
+                            width: 200,
+                            height: 150,
+                            scale: sheet.scale,
+                          };
+                          addViewport(vp);
+                        }}
+                      >
+                        {labels.addViewport}
+                      </button>
+                    </div>
+                    {(sheet.viewports ?? []).map((vp) => (
+                      <div key={vp.id} style={{ display: 'grid', gridTemplateColumns: '100px 1fr 60px 60px 70px 70px auto', gap: 6, alignItems: 'end', marginBottom: 4 }}>
+                        <ReadonlyField label={labels.id} value={vp.id} />
+                        <SelectField
+                          label={labels.viewId}
+                          value={vp.viewId}
+                          options={data.views.map((v) => v.id)}
+                          onChange={(value) => updateViewport(vp.id, { viewId: value })}
+                        />
+                        <NumberField label={labels.x} value={vp.x} onChange={(value) => updateViewport(vp.id, { x: value })} />
+                        <NumberField label={labels.y} value={vp.y} onChange={(value) => updateViewport(vp.id, { y: value })} />
+                        <NumberField label={labels.width} value={vp.width} onChange={(value) => updateViewport(vp.id, { width: value })} />
+                        <NumberField label={labels.height} value={vp.height} onChange={(value) => updateViewport(vp.id, { height: value })} />
+                        <DeleteButton label={labels.removeViewport} onClick={() => removeViewport(vp.id)} />
+                      </div>
+                    ))}
                   </div>
                 </div>
               ))}

--- a/src/features/project/PrintPreviewDialog.tsx
+++ b/src/features/project/PrintPreviewDialog.tsx
@@ -32,6 +32,7 @@ export function PrintPreviewDialog({ onClose }: Props) {
   if (!data) return null;
 
   const sheet = data.sheets.find((s) => s.id === sheetId);
+  const viewports = sheet?.viewports ?? [];
   const paper = sheet ? PAPER_SIZES[sheet.paperSize] ?? PAPER_SIZES.A3 : PAPER_SIZES.A3;
   const aspectRatio = paper.width / paper.height;
 
@@ -115,6 +116,7 @@ export function PrintPreviewDialog({ onClose }: Props) {
           <div style={{ marginTop: 8, fontSize: 11, color: 'var(--text-secondary)', textAlign: 'center' }}>
             {sheet.paperSize} &mdash; {sheet.scale}
             {sheet.titleBlock?.drawingTitle ? ` &mdash; ${sheet.titleBlock.drawingTitle}` : ''}
+            {viewports.length > 0 && ` | ${viewports.length} viewport(s)`}
           </div>
         )}
 

--- a/src/features/project/PrintPreviewDialog.tsx
+++ b/src/features/project/PrintPreviewDialog.tsx
@@ -1,0 +1,129 @@
+import { useState, useMemo } from 'react';
+import { useProjectStore } from '@/app/store';
+import { useI18n } from '@/i18n';
+import { exportSvg } from '@/domain/export/svgExport';
+
+const PAPER_SIZES: Record<string, { width: number; height: number }> = {
+  A0: { width: 1189, height: 841 },
+  A1: { width: 841, height: 594 },
+  A2: { width: 594, height: 420 },
+  A3: { width: 420, height: 297 },
+  A4: { width: 297, height: 210 },
+};
+
+interface Props {
+  onClose: () => void;
+}
+
+export function PrintPreviewDialog({ onClose }: Props) {
+  const data = useProjectStore((s) => s.data);
+  const { t } = useI18n();
+  const [sheetId, setSheetId] = useState(data?.sheets[0]?.id ?? '');
+
+  const svgContent = useMemo(() => {
+    if (!data || !sheetId) return null;
+    try {
+      return exportSvg(data, sheetId);
+    } catch {
+      return null;
+    }
+  }, [data, sheetId]);
+
+  if (!data) return null;
+
+  const sheet = data.sheets.find((s) => s.id === sheetId);
+  const paper = sheet ? PAPER_SIZES[sheet.paperSize] ?? PAPER_SIZES.A3 : PAPER_SIZES.A3;
+  const aspectRatio = paper.width / paper.height;
+
+  // Compute preview dimensions to fit within a max area
+  const maxWidth = 720;
+  const maxHeight = 540;
+  let previewWidth = maxWidth;
+  let previewHeight = previewWidth / aspectRatio;
+  if (previewHeight > maxHeight) {
+    previewHeight = maxHeight;
+    previewWidth = previewHeight * aspectRatio;
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'var(--bg-modal-overlay)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          background: 'var(--bg-modal)',
+          borderRadius: 8,
+          padding: 24,
+          maxWidth: 'min(800px, calc(100vw - 32px))',
+          boxShadow: '0 8px 32px rgba(0,0,0,0.2)',
+          color: 'var(--text-primary)',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: 12, marginBottom: 12 }}>
+          <h3 style={{ margin: 0, fontSize: 16 }}>{t.printPreviewTitle}</h3>
+        </div>
+
+        <div style={{ marginBottom: 12 }}>
+          <label style={{ display: 'block', marginBottom: 4, fontSize: 12, color: 'var(--text-secondary)' }}>{t.exportSheet}</label>
+          <select
+            className="prop-select"
+            style={{ maxWidth: '100%', width: '100%' }}
+            value={sheetId}
+            onChange={(e) => setSheetId(e.target.value)}
+          >
+            {data.sheets.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name} ({s.paperSize}, {s.scale})
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div
+          style={{
+            width: previewWidth,
+            height: previewHeight,
+            border: '1px solid var(--border-color)',
+            background: '#ffffff',
+            overflow: 'hidden',
+            margin: '0 auto',
+          }}
+        >
+          {svgContent ? (
+            <div
+              style={{ width: '100%', height: '100%' }}
+              dangerouslySetInnerHTML={{ __html: svgContent }}
+            />
+          ) : (
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', color: '#999' }}>
+              {t.printPreviewEmpty}
+            </div>
+          )}
+        </div>
+
+        {sheet && (
+          <div style={{ marginTop: 8, fontSize: 11, color: 'var(--text-secondary)', textAlign: 'center' }}>
+            {sheet.paperSize} &mdash; {sheet.scale}
+            {sheet.titleBlock?.drawingTitle ? ` &mdash; ${sheet.titleBlock.drawingTitle}` : ''}
+          </div>
+        )}
+
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 16 }}>
+          <button className="toolbar-btn" style={{ background: 'var(--border-color)', color: 'var(--text-primary)' }} onClick={onClose}>
+            {t.printPreviewClose}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -129,6 +129,30 @@ export const en: Translations = {
   helpAiText:
     'Copy the prompt template from the "AI" button and paste it into ChatGPT, Claude, or other LLMs to auto-generate JSON data. You can also paste generated JSON directly to import it.',
 
+  transformOffset: 'Offset',
+  transformMirror: 'Mirror',
+  transformArray: 'Array',
+  transformOffsetDistance: 'Distance',
+  transformMirrorAxis: 'Axis',
+  transformMirrorCopy: 'Copy',
+  transformAxisHorizontal: 'Horizontal',
+  transformAxisVertical: 'Vertical',
+  transformAxisCustom: 'Custom Angle',
+  transformAxisAngle: 'Angle',
+  transformArrayRows: 'Rows',
+  transformArrayColumns: 'Columns',
+  transformArrayRowSpacing: 'Row Spacing',
+  transformArrayColSpacing: 'Column Spacing',
+
+  coordInputPlaceholder: 'x,y or @dx,dy or @dist<angle',
+  coordInputLabel: 'Coordinate',
+
+  zoomExtents: 'Zoom Extents',
+  zoomSelection: 'Zoom Selection',
+
+  selectionWindow: 'Window',
+  selectionCrossing: 'Crossing',
+
   memberColumn: 'column',
   memberBeam: 'beam',
   memberWall: 'wall',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -159,4 +159,37 @@ export const en: Translations = {
   memberSlab: 'slab',
   memberAnnotation: 'annotation',
   memberDimension: 'dimension',
+
+  // Trim/Extend
+  toolTrim: 'Trim',
+  toolExtend: 'Extend',
+  toolFillet: 'Fillet',
+  trimPrompt: 'Click near the end of a member to trim',
+  extendPrompt: 'Click a member to extend, then click the target member',
+  filletPrompt: 'Click two walls to clean their intersection',
+
+  // Measurement
+  propArea: 'Area',
+  propPerimeter: 'Perimeter',
+
+  // Vertex editing
+  propVertices: 'Vertices',
+  vertexAdd: 'Add',
+  vertexRemove: 'Remove',
+
+  // Grouping
+  groupCreate: 'Group',
+  groupUngroup: 'Ungroup',
+  groupName: 'Group',
+  groupPromptName: 'Enter group name:',
+
+  // Print Preview
+  printPreview: 'Preview',
+  printPreviewTitle: 'Print Preview',
+  printPreviewClose: 'Close',
+  printPreviewEmpty: 'No preview available',
+
+  // Snap additions
+  snapPerpendicular: 'Perpendicular',
+  snapNearest: 'Nearest',
 };

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -192,4 +192,34 @@ export const en: Translations = {
   // Snap additions
   snapPerpendicular: 'Perpendicular',
   snapNearest: 'Nearest',
+
+  // Construction Lines
+  toolXline: 'XLine',
+  layerConstruction: 'Construction',
+
+  // Spline
+  toolSpline: 'Spline',
+
+  // Text Formatting
+  propFontWeight: 'Bold',
+  propFontStyle: 'Italic',
+  propTextDecoration: 'Underline',
+  propFontFamily: 'Font',
+
+  // External References
+  xrefTitle: 'External References',
+  xrefImport: 'Import Xref',
+  xrefRemove: 'Remove',
+
+  // Viewports
+  viewportTitle: 'Viewports',
+  viewportAdd: 'Add Viewport',
+  viewportRemove: 'Remove',
+
+  // Drawing Templates
+  templatePickerTitle: 'Select Template',
+  templateA1Structure: 'A1 Structure (1:100)',
+  templateA3Detail: 'A3 Detail (1:50)',
+  templateBlankA1: 'Blank A1',
+  templateSelectPrompt: 'Choose a template for the new project:',
 };

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -159,4 +159,37 @@ export const ja: Translations = {
   memberSlab: 'スラブ',
   memberAnnotation: '注記',
   memberDimension: '寸法線',
+
+  // Trim/Extend
+  toolTrim: 'トリム',
+  toolExtend: '延長',
+  toolFillet: 'フィレット',
+  trimPrompt: '部材の端付近をクリックしてトリム',
+  extendPrompt: '延長する部材をクリック、次にターゲット部材をクリック',
+  filletPrompt: '2つの壁をクリックして交差をクリーン',
+
+  // Measurement
+  propArea: '面積',
+  propPerimeter: '周長',
+
+  // Vertex editing
+  propVertices: '頂点',
+  vertexAdd: '追加',
+  vertexRemove: '削除',
+
+  // Grouping
+  groupCreate: 'グループ化',
+  groupUngroup: 'グループ解除',
+  groupName: 'グループ',
+  groupPromptName: 'グループ名を入力:',
+
+  // Print Preview
+  printPreview: 'プレビュー',
+  printPreviewTitle: '印刷プレビュー',
+  printPreviewClose: '閉じる',
+  printPreviewEmpty: 'プレビューなし',
+
+  // Snap additions
+  snapPerpendicular: '垂直',
+  snapNearest: '最近点',
 };

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -192,4 +192,34 @@ export const ja: Translations = {
   // Snap additions
   snapPerpendicular: '垂直',
   snapNearest: '最近点',
+
+  // Construction Lines
+  toolXline: '補助線',
+  layerConstruction: '補助線',
+
+  // Spline
+  toolSpline: 'スプライン',
+
+  // Text Formatting
+  propFontWeight: '太字',
+  propFontStyle: '斜体',
+  propTextDecoration: '下線',
+  propFontFamily: 'フォント',
+
+  // External References
+  xrefTitle: '外部参照',
+  xrefImport: '外部参照取込',
+  xrefRemove: '削除',
+
+  // Viewports
+  viewportTitle: 'ビューポート',
+  viewportAdd: 'ビューポート追加',
+  viewportRemove: '削除',
+
+  // Drawing Templates
+  templatePickerTitle: 'テンプレート選択',
+  templateA1Structure: 'A1 構造図 (1:100)',
+  templateA3Detail: 'A3 詳細図 (1:50)',
+  templateBlankA1: '白紙 A1',
+  templateSelectPrompt: '新規プロジェクトのテンプレートを選択してください:',
 };

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -129,6 +129,30 @@ export const ja: Translations = {
   helpAiText:
     'ツールバーの「AI」ボタンからプロンプトテンプレートをコピーし、ChatGPT や Claude 等の LLM に渡すことで JSON データを自動生成できます。生成された JSON を貼り付けて読み込むことも可能です。',
 
+  transformOffset: 'オフセット',
+  transformMirror: 'ミラー',
+  transformArray: '配列複写',
+  transformOffsetDistance: '距離',
+  transformMirrorAxis: '軸',
+  transformMirrorCopy: '複写',
+  transformAxisHorizontal: '水平',
+  transformAxisVertical: '垂直',
+  transformAxisCustom: 'カスタム角度',
+  transformAxisAngle: '角度',
+  transformArrayRows: '行数',
+  transformArrayColumns: '列数',
+  transformArrayRowSpacing: '行間隔',
+  transformArrayColSpacing: '列間隔',
+
+  coordInputPlaceholder: 'x,y または @dx,dy または @距離<角度',
+  coordInputLabel: '座標',
+
+  zoomExtents: '全体表示',
+  zoomSelection: '選択範囲表示',
+
+  selectionWindow: 'ウィンドウ選択',
+  selectionCrossing: 'クロス選択',
+
   memberColumn: '柱',
   memberBeam: '梁',
   memberWall: '壁',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -140,6 +140,34 @@ export interface Translations {
   helpSectionAi: string;
   helpAiText: string;
 
+  // Transform modes
+  transformOffset: string;
+  transformMirror: string;
+  transformArray: string;
+  transformOffsetDistance: string;
+  transformMirrorAxis: string;
+  transformMirrorCopy: string;
+  transformAxisHorizontal: string;
+  transformAxisVertical: string;
+  transformAxisCustom: string;
+  transformAxisAngle: string;
+  transformArrayRows: string;
+  transformArrayColumns: string;
+  transformArrayRowSpacing: string;
+  transformArrayColSpacing: string;
+
+  // Coordinate input
+  coordInputPlaceholder: string;
+  coordInputLabel: string;
+
+  // Zoom
+  zoomExtents: string;
+  zoomSelection: string;
+
+  // Rectangle selection
+  selectionWindow: string;
+  selectionCrossing: string;
+
   // member type labels
   memberColumn: string;
   memberBeam: string;

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -208,4 +208,34 @@ export interface Translations {
   // Snap additions
   snapPerpendicular: string;
   snapNearest: string;
+
+  // Construction Lines
+  toolXline: string;
+  layerConstruction: string;
+
+  // Spline
+  toolSpline: string;
+
+  // Text Formatting
+  propFontWeight: string;
+  propFontStyle: string;
+  propTextDecoration: string;
+  propFontFamily: string;
+
+  // External References
+  xrefTitle: string;
+  xrefImport: string;
+  xrefRemove: string;
+
+  // Viewports
+  viewportTitle: string;
+  viewportAdd: string;
+  viewportRemove: string;
+
+  // Drawing Templates
+  templatePickerTitle: string;
+  templateA1Structure: string;
+  templateA3Detail: string;
+  templateBlankA1: string;
+  templateSelectPrompt: string;
 }

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -175,4 +175,37 @@ export interface Translations {
   memberSlab: string;
   memberAnnotation: string;
   memberDimension: string;
+
+  // Trim/Extend
+  toolTrim: string;
+  toolExtend: string;
+  toolFillet: string;
+  trimPrompt: string;
+  extendPrompt: string;
+  filletPrompt: string;
+
+  // Measurement
+  propArea: string;
+  propPerimeter: string;
+
+  // Vertex editing
+  propVertices: string;
+  vertexAdd: string;
+  vertexRemove: string;
+
+  // Grouping
+  groupCreate: string;
+  groupUngroup: string;
+  groupName: string;
+  groupPromptName: string;
+
+  // Print Preview
+  printPreview: string;
+  printPreviewTitle: string;
+  printPreviewClose: string;
+  printPreviewEmpty: string;
+
+  // Snap additions
+  snapPerpendicular: string;
+  snapNearest: string;
 }

--- a/src/schemas/project.schema.json
+++ b/src/schemas/project.schema.json
@@ -67,6 +67,10 @@
     "issues": {
       "type": "array",
       "items": { "$ref": "#/$defs/Issue" }
+    },
+    "groups": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Group" }
     }
   },
   "$defs": {
@@ -407,6 +411,19 @@
         "level": { "type": "string", "enum": ["error", "warning", "info"] },
         "message": { "type": "string" },
         "memberId": { "type": "string" }
+      }
+    },
+    "Group": {
+      "type": "object",
+      "required": ["id", "name", "memberIds"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "name": { "type": "string" },
+        "memberIds": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
       }
     }
   }

--- a/src/schemas/project.schema.json
+++ b/src/schemas/project.schema.json
@@ -71,6 +71,14 @@
     "groups": {
       "type": "array",
       "items": { "$ref": "#/$defs/Group" }
+    },
+    "constructionLines": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/ConstructionLine" }
+    },
+    "externalRefs": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/ExternalRef" }
     }
   },
   "$defs": {
@@ -310,7 +318,7 @@
       "additionalProperties": false,
       "properties": {
         "id": { "type": "string", "minLength": 1 },
-        "type": { "type": "string", "enum": ["text", "label", "leader"] },
+        "type": { "type": "string", "enum": ["text", "label", "leader", "spline"] },
         "story": { "type": "string", "minLength": 1 },
         "x": { "type": "number" },
         "y": { "type": "number" },
@@ -318,7 +326,16 @@
         "fontSize": { "type": "number", "exclusiveMinimum": 0 },
         "rotation": { "type": "number" },
         "color": { "type": "string" },
-        "textAlign": { "$ref": "#/$defs/TextAlign" }
+        "textAlign": { "$ref": "#/$defs/TextAlign" },
+        "fontWeight": { "type": "string", "enum": ["normal", "bold"] },
+        "fontStyle": { "type": "string", "enum": ["normal", "italic"] },
+        "textDecoration": { "type": "string", "enum": ["none", "underline"] },
+        "fontFamily": { "type": "string" },
+        "points": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Point2D" },
+          "minItems": 2
+        }
       }
     },
     "Dimension": {
@@ -367,6 +384,21 @@
         "story": { "type": "string", "minLength": 1 }
       }
     },
+    "Viewport": {
+      "type": "object",
+      "required": ["id", "sheetId", "viewId", "x", "y", "width", "height", "scale"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "sheetId": { "type": "string", "minLength": 1 },
+        "viewId": { "type": "string", "minLength": 1 },
+        "x": { "type": "number" },
+        "y": { "type": "number" },
+        "width": { "type": "number", "exclusiveMinimum": 0 },
+        "height": { "type": "number", "exclusiveMinimum": 0 },
+        "scale": { "type": "string", "pattern": "^1:\\d+$" }
+      }
+    },
     "Sheet": {
       "type": "object",
       "required": ["id", "name", "paperSize", "scale", "viewIds"],
@@ -387,7 +419,11 @@
           "type": "string",
           "enum": ["standard", "compact", "minimal"]
         },
-        "titleBlock": { "$ref": "#/$defs/SheetTitleBlock" }
+        "titleBlock": { "$ref": "#/$defs/SheetTitleBlock" },
+        "viewports": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Viewport" }
+        }
       }
     },
     "SheetTitleBlock": {
@@ -401,6 +437,31 @@
         "issueDate": { "type": "string" },
         "revision": { "type": "string" },
         "note": { "type": "string" }
+      }
+    },
+    "ConstructionLine": {
+      "type": "object",
+      "required": ["id", "story", "type", "origin", "direction"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "story": { "type": "string", "minLength": 1 },
+        "type": { "type": "string", "enum": ["xline", "ray"] },
+        "origin": { "$ref": "#/$defs/Point2D" },
+        "direction": { "$ref": "#/$defs/Point2D" }
+      }
+    },
+    "ExternalRef": {
+      "type": "object",
+      "required": ["id", "name", "data", "offsetX", "offsetY", "visible"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "name": { "type": "string" },
+        "data": { "$ref": "#" },
+        "offsetX": { "type": "number" },
+        "offsetY": { "type": "number" },
+        "visible": { "type": "boolean" }
       }
     },
     "Issue": {


### PR DESCRIPTION
## Summary
市販2D CADの主要機能を19項目追加。矩形選択・座標入力・変形ツール・トリム/延長・頂点編集・計測・グループ・印刷プレビュー・スナップ強化・補助線・外部参照・ビューポート・スプライン・テキスト書式・図面テンプレートを実装。

## Changes (3 commits, +2,825 lines)

### High Priority — 作図効率の基盤
| Feature | Details |
|---------|---------|
| **矩形選択** | 左→右=窓選択(青実線)、右→左=交差選択(緑破線) |
| **座標入力** | `x,y` / `@dx,dy` / `@dist<angle` — 描画ツール中に数値入力 |
| **オフセット** | 変形ダイアログ→Offset、垂直方向に平行コピー |
| **ミラー** | 水平/垂直/角度指定、コピー有無選択 |
| **配列複写** | 行×列、行間隔・列間隔指定 |
| **ズーム全体/選択** | `Z` / `Shift+Z` / ツールバーボタン |

### Medium Priority — 編集・計測・管理
| Feature | Details |
|---------|---------|
| **トリム/延長** | 交差点で部材を切断/延長 |
| **フィレット** | 壁交差の整理（clean intersection） |
| **頂点編集** | スラブ頂点の追加/削除/移動（PropertyPanel） |
| **面積/周長計測** | スラブ面積(m2)・周長、線形部材長さを自動表示 |
| **グループ** | `Ctrl+G`/`Ctrl+Shift+G`、クリックで全体選択 |
| **印刷プレビュー** | SVGプレビュー、シート選択 |
| **スナップ追加** | 垂直・最近点スナップ |

### Low Priority — 高度な作図・連携
| Feature | Details |
|---------|---------|
| **補助線(xline/ray)** | 無限長参照線、constructionレイヤー |
| **外部参照(Xref)** | JSONファイルを読取専用グレー表示で参照 |
| **ビューポート** | シート内に複数ビュー配置 |
| **スプライン曲線** | Catmull-Rom→Bezier変換、SVG/DXF出力対応 |
| **テキスト書式** | 太字/斜体/下線/フォント選択 |
| **図面テンプレート** | A1構造/A3詳細/空白A1プリセット |

### New files
- `src/features/editor2d/CoordinateInputDialog.tsx`
- `src/domain/structural/editTrim.ts`
- `src/domain/geometry/measurement.ts`
- `src/features/project/PrintPreviewDialog.tsx`
- `src/domain/templates/drawingTemplates.ts`

## Test plan
- [ ] `npm test` — 全32テスト通過確認済
- [ ] `npm run build` — ビルド成功確認済
- [ ] 矩形選択：左→右ドラッグで窓選択、右→左で交差選択
- [ ] 座標入力：描画ツール中に `1000,2000` や `@500,0` を入力
- [ ] 変形ダイアログ：Move/Copy/Scale/Stretch/Offset/Mirror/Array全モード
- [ ] トリム/延長：交差する2部材でTrim/Extend動作
- [ ] スラブ頂点編集：PropertyPanelで頂点追加/削除/座標変更
- [ ] グループ：Ctrl+Gでグループ化、クリックで全体選択
- [ ] 印刷プレビュー：シート選択でSVGプレビュー表示
- [ ] 補助線：Xlineツールで2点クリック→無限長線表示
- [ ] 外部参照：Xref Importで他JSONをグレー表示参照
- [ ] スプライン：複数点クリック→ダブルクリックで滑らかな曲線
- [ ] テキスト書式：太字/斜体/下線/フォント変更
- [ ] テンプレート：New→テンプレート選択でプリセット読み込み
- [ ] 既存JSONファイルの後方互換性（新プロパティはすべてoptional）


🤖 Generated with [Claude Code](https://claude.com/claude-code)