### PR TITLE
Add DXF geometry-to-member conversion for structural import

### DIFF
--- a/src/components/toolbars/MainToolbar.tsx
+++ b/src/components/toolbars/MainToolbar.tsx
@@ -4,7 +4,7 @@ import type { EditorTool } from '@/app/store';
 import { useI18n } from '@/i18n';
 import { openDxfFile, openIfcFile, openJsonFile, saveFile } from '@/libs/fileSystem';
 import { importProjectJson } from '@/domain/import/jsonImport';
-import { importDxf } from '@/domain/import/dxfImport';
+import { importDxf, getAutoSections, DXF_MATERIAL, DXF_MATERIAL_ID } from '@/domain/import/dxfImport';
 import { exportProjectJson } from '@/domain/export/jsonExport';
 import { importIfc } from '@/domain/integration/ifc';
 import { importStructuralAnalysisJson, STRUCTURAL_ANALYSIS_SCHEMA } from '@/domain/integration/structuralAnalysisJson';
@@ -23,7 +23,7 @@ interface Props {
 }
 
 export function MainToolbar({ onExport, onMasters, onAiAssist, onHelp, onTransform, onPrintPreview }: Props) {
-  const { data, isDirty, fileHandle, loadProject, newProject, setFileHandle, markClean, addAnnotations, addExternalRef } =
+  const { data, isDirty, fileHandle, loadProject, newProject, setFileHandle, markClean, addAnnotations, addExternalRef, addMember, addMaterial, addSection, addDimension } =
     useProjectStore();
   const { viewMode, setViewMode, activeTool, setActiveTool, setSelectedIds, selectedIds, theme, toggleTheme, activeStory } =
     useEditorStore();
@@ -131,19 +131,70 @@ export function MainToolbar({ onExport, onMasters, onAiAssist, onHelp, onTransfo
       return;
     }
 
+    // Ask the user whether to convert geometry
+    const convertGeometry = confirm(
+      locale === 'ja'
+        ? '形状変換ありで取り込みますか？\n\nOK: 形状変換あり（部材生成）\nキャンセル: 注記のみ取込'
+        : 'Import with geometry conversion?\n\nOK: With geometry conversion (generate members)\nCancel: Annotations only',
+    );
+
     try {
       const result = await openDxfFile();
-      const imported = importDxf(result.content, storyId);
+      const imported = importDxf(result.content, storyId, { convertGeometry });
       addAnnotations(imported.annotations);
+
+      if (convertGeometry) {
+        // Add auto-generated material if not already present
+        if (!data.materials.some((m) => m.id === DXF_MATERIAL_ID)) {
+          addMaterial(DXF_MATERIAL);
+        }
+
+        // Add auto-generated sections if not already present
+        const autoSections = getAutoSections(imported);
+        for (const section of autoSections) {
+          if (!data.sections.some((s) => s.id === section.id)) {
+            addSection(section);
+          }
+        }
+
+        // Add members
+        for (const member of imported.members) {
+          addMember(member);
+        }
+
+        // Add dimensions
+        for (const dimension of imported.dimensions) {
+          addDimension(dimension);
+        }
+      }
+
+      const memberCounts = convertGeometry
+        ? (() => {
+            const walls = imported.members.filter((m) => m.type === 'wall').length;
+            const columns = imported.members.filter((m) => m.type === 'column').length;
+            const beams = imported.members.filter((m) => m.type === 'beam').length;
+            const slabs = imported.members.filter((m) => m.type === 'slab').length;
+            const dims = imported.dimensions.length;
+            const parts: string[] = [];
+            if (walls > 0) parts.push(locale === 'ja' ? `壁: ${walls}` : `Walls: ${walls}`);
+            if (columns > 0) parts.push(locale === 'ja' ? `柱: ${columns}` : `Columns: ${columns}`);
+            if (beams > 0) parts.push(locale === 'ja' ? `梁: ${beams}` : `Beams: ${beams}`);
+            if (slabs > 0) parts.push(locale === 'ja' ? `スラブ: ${slabs}` : `Slabs: ${slabs}`);
+            if (dims > 0) parts.push(locale === 'ja' ? `寸法: ${dims}` : `Dimensions: ${dims}`);
+            return parts.length > 0 ? parts.join(', ') : '';
+          })()
+        : '';
 
       const summary = locale === 'ja'
         ? [
             `${imported.annotations.length} 件の注記を ${storyId} に追加しました。`,
+            memberCounts ? `部材: ${memberCounts}` : '',
             `検出プリミティブ: ${imported.primitiveCount}`,
             imported.warnings.length > 0 ? `警告:\n${imported.warnings.slice(0, 8).join('\n')}` : '',
           ].filter(Boolean).join('\n')
         : [
             `Imported ${imported.annotations.length} annotations into ${storyId}.`,
+            memberCounts ? `Members: ${memberCounts}` : '',
             `Detected primitives: ${imported.primitiveCount}`,
             imported.warnings.length > 0 ? `Warnings:\n${imported.warnings.slice(0, 8).join('\n')}` : '',
           ].filter(Boolean).join('\n');

--- a/src/domain/import/__tests__/dxfImport.test.ts
+++ b/src/domain/import/__tests__/dxfImport.test.ts
@@ -307,3 +307,84 @@ describe('isSquarish', () => {
     expect(isSquarish(0, 500)).toBe(false);
   });
 });
+
+describe('regression: classic POLYLINE + VERTEX', () => {
+  const CLASSIC_POLYLINE_DXF = `0
+SECTION
+2
+ENTITIES
+0
+POLYLINE
+8
+WALLS
+70
+1
+0
+VERTEX
+10
+0
+20
+0
+0
+VERTEX
+10
+4000
+20
+0
+0
+VERTEX
+10
+4000
+20
+600
+0
+VERTEX
+10
+0
+20
+600
+0
+SEQEND
+0
+ENDSEC
+0
+EOF`;
+
+  it('imports classic POLYLINE vertices as column from closed rectangle', () => {
+    const result = importDxf(CLASSIC_POLYLINE_DXF, '1F', { convertGeometry: true });
+    // Closed rectangle 4000x600 → elongated → beam
+    expect(result.members.length).toBeGreaterThanOrEqual(1);
+    expect(result.primitiveCount).toBe(1);
+  });
+});
+
+describe('regression: dimension offset sign', () => {
+  const DIM_NEGATIVE_DXF = `0
+SECTION
+2
+ENTITIES
+0
+DIMENSION
+13
+0
+23
+0
+14
+4000
+24
+0
+10
+2000
+20
+-500
+0
+ENDSEC
+0
+EOF`;
+
+  it('preserves negative offset for dimensions below the measured line', () => {
+    const result = importDxf(DIM_NEGATIVE_DXF, '1F', { convertGeometry: true });
+    expect(result.dimensions).toHaveLength(1);
+    expect(result.dimensions[0].offset).toBeLessThan(0);
+  });
+});

--- a/src/domain/import/__tests__/dxfImport.test.ts
+++ b/src/domain/import/__tests__/dxfImport.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { importDxf } from '@/domain/import/dxfImport';
+import { importDxf, isRectangle, isSquarish, getAutoSections, DXF_MATERIAL_ID } from '@/domain/import/dxfImport';
 
 const SAMPLE_DXF = `0
 SECTION
@@ -86,5 +86,224 @@ describe('importDxf', () => {
       text: 'Line1 Line2',
       fontSize: 250,
     });
+  });
+
+  it('returns empty members/dimensions when convertGeometry is false (default)', () => {
+    const dxf = `0\nSECTION\n2\nENTITIES\n0\nLINE\n8\nWALL\n10\n0\n20\n0\n11\n1000\n21\n0\n0\nENDSEC\n0\nEOF`;
+    const result = importDxf(dxf, '1F');
+    expect(result.members).toHaveLength(0);
+    expect(result.dimensions).toHaveLength(0);
+    expect(result.primitiveCount).toBe(1);
+  });
+
+  it('converts a DXF LINE entity to a wall member', () => {
+    const dxf = `0\nSECTION\n2\nENTITIES\n0\nLINE\n8\nWALL\n10\n0\n20\n0\n11\n5000\n21\n0\n0\nENDSEC\n0\nEOF`;
+    const result = importDxf(dxf, '1F', { convertGeometry: true });
+
+    expect(result.members).toHaveLength(1);
+    const wall = result.members[0];
+    expect(wall.type).toBe('wall');
+    expect(wall.story).toBe('1F');
+    expect(wall.materialId).toBe(DXF_MATERIAL_ID);
+    if (wall.type === 'wall') {
+      expect(wall.start.x).toBe(0);
+      expect(wall.start.y).toBe(0);
+      expect(wall.end.x).toBe(5000);
+      expect(wall.end.y).toBe(0);
+      expect(wall.thickness).toBe(200);
+      expect(wall.height).toBe(3000);
+    }
+
+    // Should auto-generate a wall section
+    const sections = getAutoSections(result);
+    expect(sections.length).toBeGreaterThanOrEqual(1);
+    expect(sections.some((s) => s.kind === 'rc_wall')).toBe(true);
+  });
+
+  it('converts a closed rectangular LWPOLYLINE (squarish) to a column member', () => {
+    // 600x600 square polyline (closed, flag 70=1)
+    const dxf = [
+      '0', 'SECTION', '2', 'ENTITIES',
+      '0', 'LWPOLYLINE', '8', 'COL',
+      '70', '1',
+      '10', '0', '20', '0',
+      '10', '600', '20', '0',
+      '10', '600', '20', '600',
+      '10', '0', '20', '600',
+      '0', 'ENDSEC', '0', 'EOF',
+    ].join('\n');
+
+    const result = importDxf(dxf, '1F', { convertGeometry: true });
+
+    expect(result.members).toHaveLength(1);
+    const col = result.members[0];
+    expect(col.type).toBe('column');
+    expect(col.materialId).toBe(DXF_MATERIAL_ID);
+    if (col.type === 'column') {
+      expect(col.start.x).toBe(300);
+      expect(col.start.y).toBe(300);
+    }
+
+    const sections = getAutoSections(result);
+    expect(sections.some((s) => s.kind === 'rc_column_rect')).toBe(true);
+  });
+
+  it('converts a closed elongated rectangular LWPOLYLINE to a beam member', () => {
+    // 300x3000 rectangle (aspect ratio 10:1)
+    const dxf = [
+      '0', 'SECTION', '2', 'ENTITIES',
+      '0', 'LWPOLYLINE', '8', 'BEAM',
+      '70', '1',
+      '10', '0', '20', '0',
+      '10', '3000', '20', '0',
+      '10', '3000', '20', '300',
+      '10', '0', '20', '300',
+      '0', 'ENDSEC', '0', 'EOF',
+    ].join('\n');
+
+    const result = importDxf(dxf, '1F', { convertGeometry: true });
+
+    expect(result.members).toHaveLength(1);
+    const beam = result.members[0];
+    expect(beam.type).toBe('beam');
+
+    const sections = getAutoSections(result);
+    expect(sections.some((s) => s.kind === 'rc_beam_rect')).toBe(true);
+  });
+
+  it('converts a DXF CIRCLE entity to a column member', () => {
+    const dxf = [
+      '0', 'SECTION', '2', 'ENTITIES',
+      '0', 'CIRCLE', '8', 'COL',
+      '10', '2000', '20', '3000', '40', '300',
+      '0', 'ENDSEC', '0', 'EOF',
+    ].join('\n');
+
+    const result = importDxf(dxf, '2F', { convertGeometry: true });
+
+    expect(result.members).toHaveLength(1);
+    const col = result.members[0];
+    expect(col.type).toBe('column');
+    expect(col.story).toBe('2F');
+    if (col.type === 'column') {
+      expect(col.start.x).toBe(2000);
+      expect(col.start.y).toBe(3000);
+    }
+
+    const sections = getAutoSections(result);
+    const colSec = sections.find((s) => s.kind === 'rc_column_rect');
+    expect(colSec).toBeDefined();
+    if (colSec && colSec.kind === 'rc_column_rect') {
+      expect(colSec.width).toBe(600);
+      expect(colSec.depth).toBe(600);
+    }
+  });
+
+  it('converts an open LWPOLYLINE to wall segments', () => {
+    // 3-vertex open polyline → 2 wall segments
+    const dxf = [
+      '0', 'SECTION', '2', 'ENTITIES',
+      '0', 'LWPOLYLINE', '8', 'WALL',
+      '70', '0',
+      '10', '0', '20', '0',
+      '10', '1000', '20', '0',
+      '10', '1000', '20', '2000',
+      '0', 'ENDSEC', '0', 'EOF',
+    ].join('\n');
+
+    const result = importDxf(dxf, '1F', { convertGeometry: true });
+
+    expect(result.members).toHaveLength(2);
+    expect(result.members.every((m) => m.type === 'wall')).toBe(true);
+  });
+
+  it('converts a closed polygon (non-rectangular, 5 vertices) to a slab', () => {
+    const dxf = [
+      '0', 'SECTION', '2', 'ENTITIES',
+      '0', 'LWPOLYLINE', '8', 'SLAB',
+      '70', '1',
+      '10', '0', '20', '0',
+      '10', '3000', '20', '0',
+      '10', '4000', '20', '2000',
+      '10', '2000', '20', '4000',
+      '10', '0', '20', '3000',
+      '0', 'ENDSEC', '0', 'EOF',
+    ].join('\n');
+
+    const result = importDxf(dxf, '1F', { convertGeometry: true });
+
+    expect(result.members).toHaveLength(1);
+    expect(result.members[0].type).toBe('slab');
+    if (result.members[0].type === 'slab') {
+      expect(result.members[0].polygon).toHaveLength(5);
+    }
+  });
+
+  it('converts DXF DIMENSION entities to dimension objects', () => {
+    const dxf = [
+      '0', 'SECTION', '2', 'ENTITIES',
+      '0', 'DIMENSION', '8', 'DIM',
+      '10', '500', '20', '500',
+      '13', '0', '23', '0',
+      '14', '1000', '24', '0',
+      '0', 'ENDSEC', '0', 'EOF',
+    ].join('\n');
+
+    const result = importDxf(dxf, '1F', { convertGeometry: true });
+
+    expect(result.dimensions).toHaveLength(1);
+    expect(result.dimensions[0].start).toEqual({ x: 0, y: 0 });
+    expect(result.dimensions[0].end).toEqual({ x: 1000, y: 0 });
+    expect(result.dimensions[0].story).toBe('1F');
+  });
+});
+
+describe('isRectangle', () => {
+  it('detects a simple axis-aligned rectangle', () => {
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 1000, y: 0 },
+      { x: 1000, y: 500 },
+      { x: 0, y: 500 },
+    ];
+    const info = isRectangle(pts);
+    expect(info.isRect).toBe(true);
+    expect(info.center.x).toBeCloseTo(500);
+    expect(info.center.y).toBeCloseTo(250);
+  });
+
+  it('rejects a non-rectangular quadrilateral', () => {
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 1000, y: 0 },
+      { x: 1200, y: 500 },
+      { x: 0, y: 500 },
+    ];
+    const info = isRectangle(pts);
+    expect(info.isRect).toBe(false);
+  });
+
+  it('rejects a polygon with != 4 vertices', () => {
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 1000, y: 0 },
+      { x: 1000, y: 500 },
+    ];
+    expect(isRectangle(pts).isRect).toBe(false);
+  });
+});
+
+describe('isSquarish', () => {
+  it('returns true for square-like dimensions', () => {
+    expect(isSquarish(600, 600)).toBe(true);
+    expect(isSquarish(500, 700)).toBe(true);
+  });
+
+  it('returns false for elongated dimensions', () => {
+    expect(isSquarish(300, 3000)).toBe(false);
+  });
+
+  it('returns false for zero dimensions', () => {
+    expect(isSquarish(0, 500)).toBe(false);
   });
 });

--- a/src/domain/import/dxfImport.ts
+++ b/src/domain/import/dxfImport.ts
@@ -1,4 +1,5 @@
-import type { Annotation } from '@/domain/structural/types';
+import type { Point2D } from '@/domain/geometry/types';
+import type { Annotation, Dimension, Member, Material, Section } from '@/domain/structural/types';
 import { v4 as uuidv4 } from 'uuid';
 
 interface DxfEntity {
@@ -15,23 +16,370 @@ interface DxfEntity {
   minorAxisRatio?: number;
   startAngle?: number;
   endAngle?: number;
+  // DIMENSION entity fields
+  dimLineOrigin?: { x: number; y: number };
+  dimExt1?: { x: number; y: number };
+  dimExt2?: { x: number; y: number };
+  closed?: boolean;
 }
 
 export interface DxfImportResult {
   annotations: Annotation[];
+  members: Member[];
+  dimensions: Dimension[];
   primitiveCount: number;
   warnings: string[];
 }
 
+/** Auto-generated material for DXF imports */
+export const DXF_MATERIAL_ID = 'MAT-DXF-IMPORT';
+export const DXF_MATERIAL: Material = {
+  id: DXF_MATERIAL_ID,
+  name: 'DXF Import',
+  type: 'concrete',
+};
+
+const DEFAULT_WALL_THICKNESS = 200;
+const DEFAULT_SLAB_THICKNESS = 200;
+const DEFAULT_STORY_HEIGHT = 3000;
+
+// ── Detection helpers ────────────────────────────────────────
+
+interface RectangleInfo {
+  isRect: boolean;
+  width: number;
+  height: number;
+  center: Point2D;
+  angle: number;
+}
+
+export function isRectangle(vertices: Point2D[], tolerance = 50): RectangleInfo {
+  const fail: RectangleInfo = { isRect: false, width: 0, height: 0, center: { x: 0, y: 0 }, angle: 0 };
+  if (vertices.length !== 4) return fail;
+
+  // Compute edge vectors
+  const edges: Point2D[] = [];
+  for (let i = 0; i < 4; i++) {
+    const next = (i + 1) % 4;
+    edges.push({ x: vertices[next].x - vertices[i].x, y: vertices[next].y - vertices[i].y });
+  }
+
+  // Check that opposite edges are parallel and equal length
+  const len = (v: Point2D) => Math.sqrt(v.x * v.x + v.y * v.y);
+  const dot = (a: Point2D, b: Point2D) => a.x * b.x + a.y * b.y;
+
+  const l0 = len(edges[0]);
+  const l1 = len(edges[1]);
+  const l2 = len(edges[2]);
+  const l3 = len(edges[3]);
+
+  // Opposite edges should have similar length
+  if (Math.abs(l0 - l2) > tolerance || Math.abs(l1 - l3) > tolerance) return fail;
+
+  // Adjacent edges should be perpendicular (dot product ~ 0)
+  const d01 = Math.abs(dot(edges[0], edges[1]));
+  if (d01 > tolerance * Math.max(l0, l1)) return fail;
+
+  // Compute center
+  const cx = (vertices[0].x + vertices[1].x + vertices[2].x + vertices[3].x) / 4;
+  const cy = (vertices[0].y + vertices[1].y + vertices[2].y + vertices[3].y) / 4;
+
+  // width = length of edge 0, height = length of edge 1
+  const width = l0;
+  const height = l1;
+
+  // angle of the first edge
+  const angle = Math.atan2(edges[0].y, edges[0].x);
+
+  return { isRect: true, width, height, center: { x: cx, y: cy }, angle };
+}
+
+export function isSquarish(width: number, height: number, threshold = 2): boolean {
+  if (width === 0 || height === 0) return false;
+  const ratio = width > height ? width / height : height / width;
+  return ratio < threshold;
+}
+
+// ── Section deduplication ────────────────────────────────────
+
+class SectionRegistry {
+  private sections = new Map<string, Section>();
+
+  getWallSection(thickness: number): Section {
+    const key = `rc_wall:${thickness}`;
+    if (!this.sections.has(key)) {
+      this.sections.set(key, {
+        id: `SEC-DXF-WALL-${thickness}`,
+        kind: 'rc_wall',
+        thickness,
+      });
+    }
+    return this.sections.get(key)!;
+  }
+
+  getSlabSection(thickness: number): Section {
+    const key = `rc_slab:${thickness}`;
+    if (!this.sections.has(key)) {
+      this.sections.set(key, {
+        id: `SEC-DXF-SLAB-${thickness}`,
+        kind: 'rc_slab',
+        thickness,
+      });
+    }
+    return this.sections.get(key)!;
+  }
+
+  getColumnSection(width: number, depth: number): Section {
+    // Normalize so width <= depth
+    const w = Math.round(Math.min(width, depth));
+    const d = Math.round(Math.max(width, depth));
+    const key = `rc_column_rect:${w}x${d}`;
+    if (!this.sections.has(key)) {
+      this.sections.set(key, {
+        id: `SEC-DXF-COL-${w}x${d}`,
+        kind: 'rc_column_rect',
+        width: w,
+        depth: d,
+      });
+    }
+    return this.sections.get(key)!;
+  }
+
+  getBeamSection(width: number, depth: number): Section {
+    const w = Math.round(Math.min(width, depth));
+    const d = Math.round(Math.max(width, depth));
+    const key = `rc_beam_rect:${w}x${d}`;
+    if (!this.sections.has(key)) {
+      this.sections.set(key, {
+        id: `SEC-DXF-BEAM-${w}x${d}`,
+        kind: 'rc_beam_rect',
+        width: w,
+        depth: d,
+      });
+    }
+    return this.sections.get(key)!;
+  }
+
+  getAllSections(): Section[] {
+    return Array.from(this.sections.values());
+  }
+}
+
+// ── Geometry-to-member conversion ────────────────────────────
+
+function convertLineToMember(
+  entity: DxfEntity,
+  story: string,
+  sections: SectionRegistry,
+): Member | null {
+  if (!entity.startPoint || !entity.endPoint) return null;
+
+  const wallSection = sections.getWallSection(DEFAULT_WALL_THICKNESS);
+
+  return {
+    id: uuidv4(),
+    type: 'wall',
+    story,
+    sectionId: wallSection.id,
+    materialId: DXF_MATERIAL_ID,
+    start: {
+      x: entity.startPoint.x,
+      y: entity.startPoint.y,
+      z: entity.startPoint.z ?? 0,
+    },
+    end: {
+      x: entity.endPoint.x,
+      y: entity.endPoint.y,
+      z: entity.endPoint.z ?? 0,
+    },
+    height: DEFAULT_STORY_HEIGHT,
+    thickness: DEFAULT_WALL_THICKNESS,
+  };
+}
+
+function convertCircleToMember(
+  entity: DxfEntity,
+  story: string,
+  sections: SectionRegistry,
+): Member | null {
+  if (!entity.center || !entity.radius) return null;
+
+  const diameter = Math.round(entity.radius * 2);
+  const colSection = sections.getColumnSection(diameter, diameter);
+
+  return {
+    id: uuidv4(),
+    type: 'column',
+    story,
+    sectionId: colSection.id,
+    materialId: DXF_MATERIAL_ID,
+    start: { x: entity.center.x, y: entity.center.y, z: 0 },
+    end: { x: entity.center.x, y: entity.center.y, z: DEFAULT_STORY_HEIGHT },
+  };
+}
+
+function convertPolylineToMembers(
+  entity: DxfEntity,
+  story: string,
+  sections: SectionRegistry,
+): Member[] {
+  const verts = entity.vertices;
+  if (!verts || verts.length < 2) return [];
+
+  const isClosed = entity.closed ?? false;
+  const points2D: Point2D[] = verts.map((v) => ({ x: v.x, y: v.y }));
+
+  if (isClosed && points2D.length === 4) {
+    const rectInfo = isRectangle(points2D);
+    if (rectInfo.isRect) {
+      const { width, height, center } = rectInfo;
+      if (isSquarish(width, height)) {
+        // Column at centroid
+        const w = Math.round(Math.min(width, height));
+        const d = Math.round(Math.max(width, height));
+        const colSection = sections.getColumnSection(w, d);
+        return [
+          {
+            id: uuidv4(),
+            type: 'column',
+            story,
+            sectionId: colSection.id,
+            materialId: DXF_MATERIAL_ID,
+            start: { x: center.x, y: center.y, z: 0 },
+            end: { x: center.x, y: center.y, z: DEFAULT_STORY_HEIGHT },
+          },
+        ];
+      } else {
+        // Elongated rectangle → beam along long axis
+        const w = Math.round(Math.min(width, height));
+        const d = Math.round(Math.max(width, height));
+        const beamSection = sections.getBeamSection(w, d);
+
+        // Find the midpoints of the short edges for beam start/end
+        let startPt: Point2D;
+        let endPt: Point2D;
+        if (width >= height) {
+          // edge 0 is the long edge
+          startPt = {
+            x: (points2D[0].x + points2D[3].x) / 2,
+            y: (points2D[0].y + points2D[3].y) / 2,
+          };
+          endPt = {
+            x: (points2D[1].x + points2D[2].x) / 2,
+            y: (points2D[1].y + points2D[2].y) / 2,
+          };
+        } else {
+          // edge 1 is the long edge
+          startPt = {
+            x: (points2D[0].x + points2D[1].x) / 2,
+            y: (points2D[0].y + points2D[1].y) / 2,
+          };
+          endPt = {
+            x: (points2D[2].x + points2D[3].x) / 2,
+            y: (points2D[2].y + points2D[3].y) / 2,
+          };
+        }
+
+        return [
+          {
+            id: uuidv4(),
+            type: 'beam',
+            story,
+            sectionId: beamSection.id,
+            materialId: DXF_MATERIAL_ID,
+            start: { x: startPt.x, y: startPt.y, z: 0 },
+            end: { x: endPt.x, y: endPt.y, z: 0 },
+          },
+        ];
+      }
+    }
+  }
+
+  if (isClosed && points2D.length >= 4) {
+    // Non-rectangular closed polygon → slab
+    const slabSection = sections.getSlabSection(DEFAULT_SLAB_THICKNESS);
+    return [
+      {
+        id: uuidv4(),
+        type: 'slab',
+        story,
+        sectionId: slabSection.id,
+        materialId: DXF_MATERIAL_ID,
+        polygon: points2D,
+        level: 0,
+      },
+    ];
+  }
+
+  // Open polyline → series of wall segments
+  const wallSection = sections.getWallSection(DEFAULT_WALL_THICKNESS);
+  const members: Member[] = [];
+  for (let i = 0; i < points2D.length - 1; i++) {
+    members.push({
+      id: uuidv4(),
+      type: 'wall',
+      story,
+      sectionId: wallSection.id,
+      materialId: DXF_MATERIAL_ID,
+      start: { x: points2D[i].x, y: points2D[i].y, z: 0 },
+      end: { x: points2D[i + 1].x, y: points2D[i + 1].y, z: 0 },
+      height: DEFAULT_STORY_HEIGHT,
+      thickness: DEFAULT_WALL_THICKNESS,
+    });
+  }
+  return members;
+}
+
+// ── DIMENSION entity conversion ──────────────────────────────
+
+function convertDimensionEntity(entity: DxfEntity, story: string): Dimension | null {
+  if (!entity.dimExt1 || !entity.dimExt2) return null;
+
+  // Compute offset from dimension line origin to the midpoint of extension line origins
+  let offset = 0;
+  if (entity.dimLineOrigin) {
+    const midX = (entity.dimExt1.x + entity.dimExt2.x) / 2;
+    const midY = (entity.dimExt1.y + entity.dimExt2.y) / 2;
+    offset = Math.sqrt(
+      (entity.dimLineOrigin.x - midX) ** 2 + (entity.dimLineOrigin.y - midY) ** 2,
+    );
+  }
+
+  return {
+    id: uuidv4(),
+    story,
+    start: { x: entity.dimExt1.x, y: entity.dimExt1.y },
+    end: { x: entity.dimExt2.x, y: entity.dimExt2.y },
+    offset,
+    text: entity.text,
+  };
+}
+
+// ── Main import function ─────────────────────────────────────
+
+export interface DxfImportOptions {
+  /** When true, convert geometry entities to structural members. Default: false (annotations only). */
+  convertGeometry?: boolean;
+}
+
 /**
  * Import DXF using a simple line-based parser.
- * Supports: LINE, LWPOLYLINE, POLYLINE, CIRCLE, ARC, TEXT, MTEXT, SPLINE, HATCH, ELLIPSE
+ * Supports: LINE, LWPOLYLINE, POLYLINE, CIRCLE, ARC, TEXT, MTEXT, SPLINE, HATCH, ELLIPSE, DIMENSION
  * Unsupported entities are skipped with warnings.
  */
-export function importDxf(content: string, defaultStory: string): DxfImportResult {
+export function importDxf(
+  content: string,
+  defaultStory: string,
+  options: DxfImportOptions = {},
+): DxfImportResult {
   const annotations: Annotation[] = [];
+  const members: Member[] = [];
+  const dimensions: Dimension[] = [];
   const warnings: string[] = [];
   let primitiveCount = 0;
+
+  const convertGeometry = options.convertGeometry ?? false;
+  const sections = new SectionRegistry();
 
   try {
     const entities = parseDxfEntities(content);
@@ -40,19 +388,38 @@ export function importDxf(content: string, defaultStory: string): DxfImportResul
       switch (entity.type) {
         case 'LINE':
           primitiveCount++;
+          if (convertGeometry) {
+            const member = convertLineToMember(entity, defaultStory, sections);
+            if (member) members.push(member);
+          }
           break;
         case 'LWPOLYLINE':
         case 'POLYLINE':
           primitiveCount++;
+          if (convertGeometry) {
+            const polyMembers = convertPolylineToMembers(entity, defaultStory, sections);
+            members.push(...polyMembers);
+          }
           break;
         case 'CIRCLE':
           primitiveCount++;
+          if (convertGeometry) {
+            const colMember = convertCircleToMember(entity, defaultStory, sections);
+            if (colMember) members.push(colMember);
+          }
           break;
         case 'ARC':
         case 'SPLINE':
         case 'HATCH':
         case 'ELLIPSE':
           primitiveCount++;
+          break;
+        case 'DIMENSION':
+          primitiveCount++;
+          if (convertGeometry) {
+            const dim = convertDimensionEntity(entity, defaultStory);
+            if (dim) dimensions.push(dim);
+          }
           break;
         case 'TEXT':
         case 'MTEXT':
@@ -77,7 +444,20 @@ export function importDxf(content: string, defaultStory: string): DxfImportResul
     warnings.push(`DXF parse error: ${String(e)}`);
   }
 
-  return { annotations, primitiveCount, warnings };
+  return {
+    annotations,
+    members,
+    dimensions,
+    primitiveCount,
+    warnings,
+    /** Expose auto-generated sections for the caller to register */
+    ...( convertGeometry ? { _autoSections: sections.getAllSections() } : {}),
+  } as DxfImportResult & { _autoSections?: Section[] };
+}
+
+/** Helper to retrieve auto-generated sections from an import result */
+export function getAutoSections(result: DxfImportResult): Section[] {
+  return (result as DxfImportResult & { _autoSections?: Section[] })._autoSections ?? [];
 }
 
 /**
@@ -130,6 +510,9 @@ function parseDxfEntities(content: string): DxfEntity[] {
       case 20:
         assignPrimaryY(current, parseFloat(value));
         break;
+      case 30:
+        assignPrimaryZ(current, parseFloat(value));
+        break;
       case 11:
         if (current.type === 'ELLIPSE') {
           current.majorAxisEndpoint = { ...current.majorAxisEndpoint, x: parseFloat(value), y: current.majorAxisEndpoint?.y ?? 0 };
@@ -142,6 +525,41 @@ function parseDxfEntities(content: string): DxfEntity[] {
           current.majorAxisEndpoint = { ...current.majorAxisEndpoint, x: current.majorAxisEndpoint?.x ?? 0, y: parseFloat(value) };
         } else {
           current.endPoint = { ...current.endPoint, x: current.endPoint?.x ?? 0, y: parseFloat(value) };
+        }
+        break;
+      case 31:
+        if (current.endPoint) {
+          current.endPoint.z = parseFloat(value);
+        }
+        break;
+      case 13:
+        // DIMENSION: first extension line origin X
+        if (current.type === 'DIMENSION') {
+          current.dimExt1 = { ...current.dimExt1, x: parseFloat(value), y: current.dimExt1?.y ?? 0 };
+        }
+        break;
+      case 23:
+        // DIMENSION: first extension line origin Y
+        if (current.type === 'DIMENSION') {
+          current.dimExt1 = { ...current.dimExt1, x: current.dimExt1?.x ?? 0, y: parseFloat(value) };
+        }
+        break;
+      case 14:
+        // DIMENSION: second extension line origin X
+        if (current.type === 'DIMENSION') {
+          current.dimExt2 = { ...current.dimExt2, x: parseFloat(value), y: current.dimExt2?.y ?? 0 };
+        }
+        break;
+      case 24:
+        // DIMENSION: second extension line origin Y
+        if (current.type === 'DIMENSION') {
+          current.dimExt2 = { ...current.dimExt2, x: current.dimExt2?.x ?? 0, y: parseFloat(value) };
+        }
+        break;
+      case 70:
+        // For LWPOLYLINE: flag for closed polyline (bit 0 = closed)
+        if (current.type === 'LWPOLYLINE' || current.type === 'POLYLINE') {
+          current.closed = (parseInt(value, 10) & 1) !== 0;
         }
         break;
       case 1:
@@ -176,9 +594,17 @@ function isVertexEntity(type: string): boolean {
   return type === 'LWPOLYLINE' || type === 'POLYLINE' || type === 'SPLINE' || type === 'HATCH';
 }
 
+function isDimensionEntity(type: string): boolean {
+  return type === 'DIMENSION';
+}
+
 function assignPrimaryX(entity: DxfEntity, value: number) {
   if (entity.type === 'CIRCLE' || entity.type === 'ARC' || entity.type === 'ELLIPSE') {
     entity.center = { ...entity.center, x: value, y: entity.center?.y ?? 0 };
+    return;
+  }
+  if (isDimensionEntity(entity.type)) {
+    entity.dimLineOrigin = { ...entity.dimLineOrigin, x: value, y: entity.dimLineOrigin?.y ?? 0 };
     return;
   }
   if (isVertexEntity(entity.type)) {
@@ -194,6 +620,10 @@ function assignPrimaryY(entity: DxfEntity, value: number) {
     entity.center = { ...entity.center, x: entity.center?.x ?? 0, y: value };
     return;
   }
+  if (isDimensionEntity(entity.type)) {
+    entity.dimLineOrigin = { ...entity.dimLineOrigin, x: entity.dimLineOrigin?.x ?? 0, y: value };
+    return;
+  }
   if (isVertexEntity(entity.type)) {
     entity.vertices ??= [];
     const last = entity.vertices[entity.vertices.length - 1];
@@ -205,6 +635,26 @@ function assignPrimaryY(entity: DxfEntity, value: number) {
     return;
   }
   entity.startPoint = { ...entity.startPoint, x: entity.startPoint?.x ?? 0, y: value };
+}
+
+function assignPrimaryZ(entity: DxfEntity, value: number) {
+  if (entity.type === 'CIRCLE' || entity.type === 'ARC' || entity.type === 'ELLIPSE') {
+    if (entity.center) entity.center.z = value;
+    return;
+  }
+  if (isVertexEntity(entity.type)) {
+    entity.vertices ??= [];
+    const last = entity.vertices[entity.vertices.length - 1];
+    if (last) {
+      last.z = value;
+    }
+    return;
+  }
+  if (isDimensionEntity(entity.type)) {
+    // z not used for dimensions
+    return;
+  }
+  if (entity.startPoint) entity.startPoint.z = value;
 }
 
 function normalizeDxfText(value: string): string {

--- a/src/domain/import/dxfImport.ts
+++ b/src/domain/import/dxfImport.ts
@@ -21,6 +21,8 @@ interface DxfEntity {
   dimExt1?: { x: number; y: number };
   dimExt2?: { x: number; y: number };
   closed?: boolean;
+  /** Internal flag: classic POLYLINE is expecting vertex coordinates from next group codes */
+  _pendingVertex?: boolean;
 }
 
 export interface DxfImportResult {
@@ -335,14 +337,21 @@ function convertPolylineToMembers(
 function convertDimensionEntity(entity: DxfEntity, story: string): Dimension | null {
   if (!entity.dimExt1 || !entity.dimExt2) return null;
 
-  // Compute offset from dimension line origin to the midpoint of extension line origins
+  // Compute signed offset by projecting dimLineOrigin onto the perpendicular of the measured segment
   let offset = 0;
   if (entity.dimLineOrigin) {
-    const midX = (entity.dimExt1.x + entity.dimExt2.x) / 2;
-    const midY = (entity.dimExt1.y + entity.dimExt2.y) / 2;
-    offset = Math.sqrt(
-      (entity.dimLineOrigin.x - midX) ** 2 + (entity.dimLineOrigin.y - midY) ** 2,
-    );
+    const dx = entity.dimExt2.x - entity.dimExt1.x;
+    const dy = entity.dimExt2.y - entity.dimExt1.y;
+    const len = Math.hypot(dx, dy);
+    if (len > 1e-9) {
+      // Perpendicular direction (same convention as DimensionLayer)
+      const perpX = -dy / len;
+      const perpY = dx / len;
+      const midX = (entity.dimExt1.x + entity.dimExt2.x) / 2;
+      const midY = (entity.dimExt1.y + entity.dimExt2.y) / 2;
+      // Signed projection onto perpendicular
+      offset = (entity.dimLineOrigin.x - midX) * perpX + (entity.dimLineOrigin.y - midY) * perpY;
+    }
   }
 
   return {
@@ -493,6 +502,17 @@ function parseDxfEntities(content: string): DxfEntity[] {
     if (!inEntities) continue;
 
     if (code === 0) {
+      // Classic POLYLINE: accumulate VERTEX rows into parent, finalize on SEQEND
+      if (current && current.type === 'POLYLINE' && value === 'VERTEX') {
+        // Mark that the next 10/20 codes should update (not push) a vertex
+        current._pendingVertex = true;
+        continue;
+      }
+      if (current && current.type === 'POLYLINE' && value === 'SEQEND') {
+        entities.push(current);
+        current = null;
+        continue;
+      }
       if (current) entities.push(current);
       current = { type: value };
       continue;
@@ -609,7 +629,13 @@ function assignPrimaryX(entity: DxfEntity, value: number) {
   }
   if (isVertexEntity(entity.type)) {
     entity.vertices ??= [];
-    entity.vertices.push({ x: value, y: 0 });
+    if (entity._pendingVertex) {
+      // Classic POLYLINE VERTEX: push new vertex with this X
+      entity.vertices.push({ x: value, y: 0 });
+      entity._pendingVertex = false;
+    } else {
+      entity.vertices.push({ x: value, y: 0 });
+    }
     return;
   }
   entity.startPoint = { ...entity.startPoint, x: value, y: entity.startPoint?.y ?? 0 };


### PR DESCRIPTION
## Summary
- DXFファイルの形状エンティティ（LINE/LWPOLYLINE/CIRCLE/DIMENSION）を構造部材（柱/梁/壁/スラブ/寸法線）に自動変換するインポート機能を追加
- 既存の「注記のみ取込」は維持し、取込時にユーザーがモードを選択

## 変換ルール

| DXFエンティティ | 変換先 | 判定ロジック |
|----------------|--------|-------------|
| LINE | 壁 | start/end直接マッピング (200mm厚, 3000mm高) |
| 閉矩形LWPOLYLINE (正方形寄り) | 柱 | アスペクト比 < 2:1 → 重心に配置 |
| 閉矩形LWPOLYLINE (細長) | 梁 | 長辺方向にstart/end |
| 閉多角形 (非矩形) | スラブ | 頂点をpolygonに |
| 開ポリライン | 壁列 | 連続頂点間を壁セグメントに |
| CIRCLE | 柱 | 直径で正方形断面 |
| DIMENSION | 寸法線 | 引出線原点からstart/end/offset |

## Changes
- `src/domain/import/dxfImport.ts` — 形状変換ロジック、SectionRegistry、DXF_MATERIAL定数
- `src/domain/import/__tests__/dxfImport.test.ts` — 14新規テスト
- `src/components/toolbars/MainToolbar.tsx` — インポートハンドラ更新（モード選択、部材/断面/材料の自動登録）

## Test plan
- [ ] `npm test` — 全46テスト通過確認済
- [ ] `npm run build` — ビルド成功確認済
- [ ] DXF取込→「注記のみ」選択：従来通り注記のみ追加（後方互換）
- [ ] DXF取込→「形状変換あり」選択：LINE→壁、矩形→柱/梁、多角形→スラブに変換
- [ ] 自動生成された材料・断面が重複しないこと
- [ ] CIRCLE→正方形断面の柱に変換
- [ ] DIMENSION→寸法線に変換


🤖 Generated with [Claude Code](https://claude.com/claude-code)