### PR TITLE
[codex] Add drawing step guidance

### DIFF
--- a/src/features/editor2d/DrawingGuide.tsx
+++ b/src/features/editor2d/DrawingGuide.tsx
@@ -1,0 +1,21 @@
+import type { EditorTool } from '@/app/store';
+import { useI18n } from '@/i18n';
+import { getDrawingGuideText } from './toolGuide';
+
+interface Props {
+  activeTool: EditorTool;
+  pointCount: number;
+}
+
+export function DrawingGuide({ activeTool, pointCount }: Props) {
+  const { t } = useI18n();
+  const text = getDrawingGuideText(activeTool, pointCount, t);
+
+  if (!text) return null;
+
+  return (
+    <div className="drawing-guide" role="status" aria-live="polite">
+      {text}
+    </div>
+  );
+}

--- a/src/features/editor2d/Editor2D.tsx
+++ b/src/features/editor2d/Editor2D.tsx
@@ -150,12 +150,14 @@ export function Editor2D() {
 
   return (
     <div ref={containerRef} style={{ display: 'flex', flexDirection: 'column', height: '100%', position: 'relative' }}>
-      <EditorControls2D
-        canZoomSelection={selectedIds.length > 0}
-        onZoomExtents={zoomToExtents}
-        onZoomSelection={zoomToSelection}
-      />
-      <DrawingGuide activeTool={activeTool} pointCount={drawState.points.length} />
+      <div className="editor-canvas-overlay">
+        <EditorControls2D
+          canZoomSelection={selectedIds.length > 0}
+          onZoomExtents={zoomToExtents}
+          onZoomSelection={zoomToSelection}
+        />
+        <DrawingGuide activeTool={activeTool} pointCount={drawState.points.length} />
+      </div>
       <div style={{ flex: 1, overflow: 'hidden' }}>
         <SvgCanvas
           onWorldClick={handleClick}

--- a/src/features/editor2d/Editor2D.tsx
+++ b/src/features/editor2d/Editor2D.tsx
@@ -9,6 +9,7 @@ import { DrawPreview } from './DrawPreview';
 import { useEditorInteraction } from './useEditorInteraction';
 import { CoordinateInputBar } from './CoordinateInputDialog';
 import { EditorControls2D } from './EditorControls2D';
+import { DrawingGuide } from './DrawingGuide';
 import { getAllEntityBounds, getSelectionBounds } from '@/domain/structural/editTransform';
 
 export function Editor2D() {
@@ -154,6 +155,7 @@ export function Editor2D() {
         onZoomExtents={zoomToExtents}
         onZoomSelection={zoomToSelection}
       />
+      <DrawingGuide activeTool={activeTool} pointCount={drawState.points.length} />
       <div style={{ flex: 1, overflow: 'hidden' }}>
         <SvgCanvas
           onWorldClick={handleClick}

--- a/src/features/editor2d/__tests__/drawingGuide.test.ts
+++ b/src/features/editor2d/__tests__/drawingGuide.test.ts
@@ -21,4 +21,10 @@ describe('getDrawingGuideText', () => {
     expect(getDrawingGuideText('spline', 0, en)).toBe(en.guideSplineStart);
     expect(getDrawingGuideText('spline', 1, en)).toBe(en.guideSplineNext);
   });
+
+  it('uses guide-specific keys for edit tools', () => {
+    expect(getDrawingGuideText('trim', 0, en)).toBe(en.guideTrimPrompt);
+    expect(getDrawingGuideText('extend', 0, en)).toBe(en.guideExtendSource);
+    expect(getDrawingGuideText('extend', 1, en)).toBe(en.guideExtendTarget);
+  });
 });

--- a/src/features/editor2d/__tests__/drawingGuide.test.ts
+++ b/src/features/editor2d/__tests__/drawingGuide.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { en } from '@/i18n/en';
+import { getDrawingGuideText } from '../toolGuide';
+
+describe('getDrawingGuideText', () => {
+  it('returns no guide for passive tools', () => {
+    expect(getDrawingGuideText('select', 0, en)).toBeNull();
+    expect(getDrawingGuideText('pan', 0, en)).toBeNull();
+  });
+
+  it('advances guide text for two-point tools', () => {
+    expect(getDrawingGuideText('beam', 0, en)).toBe(en.guideBeamStart);
+    expect(getDrawingGuideText('beam', 1, en)).toBe(en.guideBeamEnd);
+    expect(getDrawingGuideText('wall', 0, en)).toBe(en.guideWallStart);
+    expect(getDrawingGuideText('wall', 1, en)).toBe(en.guideWallEnd);
+  });
+
+  it('uses completion guidance for polygon-style tools', () => {
+    expect(getDrawingGuideText('slab', 0, en)).toBe(en.guideSlabStart);
+    expect(getDrawingGuideText('slab', 2, en)).toBe(en.guideSlabNext);
+    expect(getDrawingGuideText('spline', 0, en)).toBe(en.guideSplineStart);
+    expect(getDrawingGuideText('spline', 1, en)).toBe(en.guideSplineNext);
+  });
+});

--- a/src/features/editor2d/toolGuide.ts
+++ b/src/features/editor2d/toolGuide.ts
@@ -27,7 +27,7 @@ export function getDrawingGuideText(
     case 'spline':
       return pointCount === 0 ? t.guideSplineStart : t.guideSplineNext;
     case 'trim':
-      return t.trimPrompt;
+      return t.guideTrimPrompt;
     case 'extend':
       return pointCount === 0 ? t.guideExtendSource : t.guideExtendTarget;
   }

--- a/src/features/editor2d/toolGuide.ts
+++ b/src/features/editor2d/toolGuide.ts
@@ -1,0 +1,34 @@
+import type { EditorTool } from '@/app/store';
+import type { Translations } from '@/i18n';
+
+export function getDrawingGuideText(
+  tool: EditorTool,
+  pointCount: number,
+  t: Translations,
+): string | null {
+  switch (tool) {
+    case 'select':
+    case 'pan':
+      return null;
+    case 'column':
+      return t.guideColumnPlace;
+    case 'beam':
+      return pointCount === 0 ? t.guideBeamStart : t.guideBeamEnd;
+    case 'wall':
+      return pointCount === 0 ? t.guideWallStart : t.guideWallEnd;
+    case 'slab':
+      return pointCount === 0 ? t.guideSlabStart : t.guideSlabNext;
+    case 'dimension':
+      return pointCount === 0 ? t.guideDimensionStart : t.guideDimensionEnd;
+    case 'annotation':
+      return t.guideAnnotationPlace;
+    case 'xline':
+      return pointCount === 0 ? t.guideXlineStart : t.guideXlineDirection;
+    case 'spline':
+      return pointCount === 0 ? t.guideSplineStart : t.guideSplineNext;
+    case 'trim':
+      return t.trimPrompt;
+    case 'extend':
+      return pointCount === 0 ? t.guideExtendSource : t.guideExtendTarget;
+  }
+}

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -204,6 +204,7 @@ export const en: Translations = {
   guideXlineDirection: 'Click the construction line direction point',
   guideSplineStart: 'Click the first spline point',
   guideSplineNext: 'Click the next point, double-click to finish',
+  guideTrimPrompt: 'Click near the end of a member to trim',
   guideExtendSource: 'Click the member to extend',
   guideExtendTarget: 'Click the target member',
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -190,6 +190,23 @@ export const en: Translations = {
   columnZDownTooltip: 'Place columns downward from the active story level',
   columnZUpTooltip: 'Place columns upward from the active story level',
 
+  guideColumnPlace: 'Click the column location',
+  guideBeamStart: 'Click the beam start point',
+  guideBeamEnd: 'Click the beam end point',
+  guideWallStart: 'Click the wall start point',
+  guideWallEnd: 'Click the wall end point',
+  guideSlabStart: 'Click the first slab vertex',
+  guideSlabNext: 'Click the next vertex, double-click to finish',
+  guideDimensionStart: 'Click the dimension start point',
+  guideDimensionEnd: 'Click the dimension end point',
+  guideAnnotationPlace: 'Click where the annotation should be placed',
+  guideXlineStart: 'Click the construction line base point',
+  guideXlineDirection: 'Click the construction line direction point',
+  guideSplineStart: 'Click the first spline point',
+  guideSplineNext: 'Click the next point, double-click to finish',
+  guideExtendSource: 'Click the member to extend',
+  guideExtendTarget: 'Click the target member',
+
   selectionWindow: 'Window',
   selectionCrossing: 'Crossing',
 

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -204,6 +204,7 @@ export const ja: Translations = {
   guideXlineDirection: '補助線の方向点をクリック',
   guideSplineStart: 'スプラインの1点目をクリック',
   guideSplineNext: '次の点をクリック、ダブルクリックで確定',
+  guideTrimPrompt: '部材の端付近をクリックしてトリム',
   guideExtendSource: '延長する部材をクリック',
   guideExtendTarget: '延長先の部材をクリック',
 

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -190,6 +190,23 @@ export const ja: Translations = {
   columnZDownTooltip: '柱を現階レベルから下向きに配置します',
   columnZUpTooltip: '柱を現階レベルから上向きに配置します',
 
+  guideColumnPlace: '柱の配置位置をクリック',
+  guideBeamStart: '梁の始点をクリック',
+  guideBeamEnd: '梁の終点をクリック',
+  guideWallStart: '壁の始点をクリック',
+  guideWallEnd: '壁の終点をクリック',
+  guideSlabStart: 'スラブの1点目をクリック',
+  guideSlabNext: '次の頂点をクリック、ダブルクリックで確定',
+  guideDimensionStart: '寸法の始点をクリック',
+  guideDimensionEnd: '寸法の終点をクリック',
+  guideAnnotationPlace: '注記を配置する位置をクリック',
+  guideXlineStart: '補助線の基点をクリック',
+  guideXlineDirection: '補助線の方向点をクリック',
+  guideSplineStart: 'スプラインの1点目をクリック',
+  guideSplineNext: '次の点をクリック、ダブルクリックで確定',
+  guideExtendSource: '延長する部材をクリック',
+  guideExtendTarget: '延長先の部材をクリック',
+
   selectionWindow: 'ウィンドウ選択',
   selectionCrossing: 'クロス選択',
 

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -188,6 +188,24 @@ export interface Translations {
   columnZDownTooltip: string;
   columnZUpTooltip: string;
 
+  // Drawing guide
+  guideColumnPlace: string;
+  guideBeamStart: string;
+  guideBeamEnd: string;
+  guideWallStart: string;
+  guideWallEnd: string;
+  guideSlabStart: string;
+  guideSlabNext: string;
+  guideDimensionStart: string;
+  guideDimensionEnd: string;
+  guideAnnotationPlace: string;
+  guideXlineStart: string;
+  guideXlineDirection: string;
+  guideSplineStart: string;
+  guideSplineNext: string;
+  guideExtendSource: string;
+  guideExtendTarget: string;
+
   // Rectangle selection
   selectionWindow: string;
   selectionCrossing: string;

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -203,6 +203,7 @@ export interface Translations {
   guideXlineDirection: string;
   guideSplineStart: string;
   guideSplineNext: string;
+  guideTrimPrompt: string;
   guideExtendSource: string;
   guideExtendTarget: string;
 

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -240,6 +240,23 @@
   background: var(--border-color);
 }
 
+.drawing-guide {
+  position: absolute;
+  top: 52px;
+  left: 10px;
+  z-index: 20;
+  max-width: min(460px, calc(100% - 20px));
+  padding: 6px 10px;
+  border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border-color));
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--bg-panel) 94%, transparent);
+  color: var(--text-primary);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.14);
+  font-size: 12px;
+  line-height: 1.35;
+  pointer-events: none;
+}
+
 .responsive-panel-controls {
   display: none;
 }
@@ -268,6 +285,11 @@
     right: 10px;
     flex-wrap: wrap;
     overflow-x: visible;
+  }
+
+  .drawing-guide {
+    right: 10px;
+    max-width: none;
   }
 
   .responsive-panel-controls {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -186,21 +186,31 @@
   background: var(--bg-canvas);
 }
 
-.editor-floating-controls {
+.editor-canvas-overlay {
   position: absolute;
   top: 10px;
   left: 10px;
+  right: 10px;
   z-index: 20;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  pointer-events: none;
+}
+
+.editor-floating-controls {
   display: flex;
   align-items: center;
   gap: 4px;
-  max-width: calc(100% - 20px);
+  max-width: 100%;
   padding: 4px;
   border: 1px solid var(--border-color);
   border-radius: 6px;
   background: color-mix(in srgb, var(--bg-panel) 92%, transparent);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.14);
   overflow-x: auto;
+  pointer-events: auto;
 }
 
 .floating-control-btn {
@@ -241,11 +251,7 @@
 }
 
 .drawing-guide {
-  position: absolute;
-  top: 52px;
-  left: 10px;
-  z-index: 20;
-  max-width: min(460px, calc(100% - 20px));
+  max-width: min(460px, 100%);
   padding: 6px 10px;
   border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border-color));
   border-radius: 6px;
@@ -282,13 +288,12 @@
   }
 
   .editor-floating-controls {
-    right: 10px;
     flex-wrap: wrap;
     overflow-x: visible;
   }
 
   .drawing-guide {
-    right: 10px;
+    align-self: stretch;
     max-width: none;
   }
 


### PR DESCRIPTION
## Summary
- Add a small in-canvas drawing guide that changes by active tool and collected point count.
- Cover column, beam, wall, slab, dimension, annotation, construction line, spline, trim, and extend workflows.
- Add focused unit coverage for the guide text selection logic.

## Scope
This PR is intentionally limited to step guidance. It does not add angle constraints, selection filters, or snap behavior changes.

## Validation
- `npm run lint`
- `npm run build`
- `npm test`
- Headless Chrome check: sample project loaded, column tool selected, `.drawing-guide` visible with `柱の配置位置をクリック`.
