### PR TITLE
[codex] Localize active tool status

### DIFF
--- a/src/app/__tests__/toolMetadata.test.ts
+++ b/src/app/__tests__/toolMetadata.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { en } from '@/i18n/en';
 import { ja } from '@/i18n/ja';
-import { getToolLabel, getToolStatusLabel, TOOL_SHORTCUTS, TOOL_SHORTCUTS_BY_KEY } from '../toolMetadata';
+import { getToolForShortcutKey, getToolLabel, getToolStatusLabel, TOOL_SHORTCUTS, TOOL_SHORTCUTS_BY_KEY } from '../toolMetadata';
 
 describe('tool metadata', () => {
   it('localizes active tool labels', () => {
@@ -12,6 +12,8 @@ describe('tool metadata', () => {
 
   it('adds shortcut hints only for shortcut-backed tools', () => {
     expect(TOOL_SHORTCUTS_BY_KEY.b).toBe('beam');
+    expect(getToolForShortcutKey('B')).toBe('beam');
+    expect(getToolForShortcutKey('toString')).toBeUndefined();
     expect(TOOL_SHORTCUTS.beam).toBe('B');
     expect(getToolStatusLabel('beam', en)).toBe('Beam (B)');
     expect(getToolStatusLabel('trim', en)).toBe('Trim');

--- a/src/app/__tests__/toolMetadata.test.ts
+++ b/src/app/__tests__/toolMetadata.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { en } from '@/i18n/en';
+import { ja } from '@/i18n/ja';
+import { getToolLabel, getToolStatusLabel, TOOL_SHORTCUTS } from '../toolMetadata';
+
+describe('tool metadata', () => {
+  it('localizes active tool labels', () => {
+    expect(getToolLabel('column', en)).toBe('Column');
+    expect(getToolLabel('column', ja)).toBe('柱');
+    expect(getToolLabel('xline', ja)).toBe('補助線');
+  });
+
+  it('adds shortcut hints only for shortcut-backed tools', () => {
+    expect(TOOL_SHORTCUTS.beam).toBe('B');
+    expect(getToolStatusLabel('beam', en)).toBe('Beam (B)');
+    expect(getToolStatusLabel('trim', en)).toBe('Trim');
+  });
+});

--- a/src/app/__tests__/toolMetadata.test.ts
+++ b/src/app/__tests__/toolMetadata.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { en } from '@/i18n/en';
 import { ja } from '@/i18n/ja';
-import { getToolLabel, getToolStatusLabel, TOOL_SHORTCUTS } from '../toolMetadata';
+import { getToolLabel, getToolStatusLabel, TOOL_SHORTCUTS, TOOL_SHORTCUTS_BY_KEY } from '../toolMetadata';
 
 describe('tool metadata', () => {
   it('localizes active tool labels', () => {
@@ -11,6 +11,7 @@ describe('tool metadata', () => {
   });
 
   it('adds shortcut hints only for shortcut-backed tools', () => {
+    expect(TOOL_SHORTCUTS_BY_KEY.b).toBe('beam');
     expect(TOOL_SHORTCUTS.beam).toBe('B');
     expect(getToolStatusLabel('beam', en)).toBe('Beam (B)');
     expect(getToolStatusLabel('trim', en)).toBe('Trim');

--- a/src/app/toolMetadata.ts
+++ b/src/app/toolMetadata.ts
@@ -1,0 +1,48 @@
+import type { EditorTool } from '@/app/store';
+import type { Translations } from '@/i18n';
+
+export const TOOL_SHORTCUTS: Partial<Record<EditorTool, string>> = {
+  select: 'V',
+  pan: 'H',
+  column: 'C',
+  beam: 'B',
+  wall: 'W',
+  slab: 'S',
+  dimension: 'D',
+  annotation: 'T',
+};
+
+export function getToolLabel(tool: EditorTool, t: Translations): string {
+  switch (tool) {
+    case 'select':
+      return t.toolSelect;
+    case 'pan':
+      return t.toolPan;
+    case 'column':
+      return t.toolColumn;
+    case 'beam':
+      return t.toolBeam;
+    case 'wall':
+      return t.toolWall;
+    case 'slab':
+      return t.toolSlab;
+    case 'dimension':
+      return t.toolDimension;
+    case 'annotation':
+      return t.toolAnnotation;
+    case 'trim':
+      return t.toolTrim;
+    case 'extend':
+      return t.toolExtend;
+    case 'xline':
+      return t.toolXline;
+    case 'spline':
+      return t.toolSpline;
+  }
+}
+
+export function getToolStatusLabel(tool: EditorTool, t: Translations): string {
+  const label = getToolLabel(tool, t);
+  const shortcut = TOOL_SHORTCUTS[tool];
+  return shortcut ? `${label} (${shortcut})` : label;
+}

--- a/src/app/toolMetadata.ts
+++ b/src/app/toolMetadata.ts
@@ -1,16 +1,22 @@
 import type { EditorTool } from '@/app/store';
 import type { Translations } from '@/i18n';
 
-export const TOOL_SHORTCUTS: Partial<Record<EditorTool, string>> = {
-  select: 'V',
-  pan: 'H',
-  column: 'C',
-  beam: 'B',
-  wall: 'W',
-  slab: 'S',
-  dimension: 'D',
-  annotation: 'T',
-};
+export const TOOL_SHORTCUTS_BY_KEY = {
+  v: 'select',
+  h: 'pan',
+  c: 'column',
+  b: 'beam',
+  w: 'wall',
+  s: 'slab',
+  d: 'dimension',
+  t: 'annotation',
+} as const satisfies Record<string, EditorTool>;
+
+type ShortcutBackedTool = (typeof TOOL_SHORTCUTS_BY_KEY)[keyof typeof TOOL_SHORTCUTS_BY_KEY];
+
+export const TOOL_SHORTCUTS = Object.fromEntries(
+  Object.entries(TOOL_SHORTCUTS_BY_KEY).map(([key, tool]) => [tool, key.toUpperCase()]),
+) as Record<ShortcutBackedTool, string>;
 
 export function getToolLabel(tool: EditorTool, t: Translations): string {
   switch (tool) {
@@ -43,6 +49,6 @@ export function getToolLabel(tool: EditorTool, t: Translations): string {
 
 export function getToolStatusLabel(tool: EditorTool, t: Translations): string {
   const label = getToolLabel(tool, t);
-  const shortcut = TOOL_SHORTCUTS[tool];
+  const shortcut = (TOOL_SHORTCUTS as Partial<Record<EditorTool, string>>)[tool];
   return shortcut ? `${label} (${shortcut})` : label;
 }

--- a/src/app/toolMetadata.ts
+++ b/src/app/toolMetadata.ts
@@ -18,6 +18,10 @@ export const TOOL_SHORTCUTS = Object.fromEntries(
   Object.entries(TOOL_SHORTCUTS_BY_KEY).map(([key, tool]) => [tool, key.toUpperCase()]),
 ) as Record<ShortcutBackedTool, string>;
 
+export function getToolForShortcutKey(key: string): ShortcutBackedTool | undefined {
+  return (TOOL_SHORTCUTS_BY_KEY as Partial<Record<string, ShortcutBackedTool>>)[key.toLowerCase()];
+}
+
 export function getToolLabel(tool: EditorTool, t: Translations): string {
   switch (tool) {
     case 'select':

--- a/src/app/useKeyboardShortcuts.ts
+++ b/src/app/useKeyboardShortcuts.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useProjectStore, useEditorStore } from '@/app/store';
-import { TOOL_SHORTCUTS_BY_KEY } from '@/app/toolMetadata';
+import { getToolForShortcutKey } from '@/app/toolMetadata';
 
 export function useKeyboardShortcuts() {
   useEffect(() => {
@@ -60,9 +60,8 @@ export function useKeyboardShortcuts() {
 
       // Tool shortcuts (single key)
       if (!ctrl && !e.altKey) {
-        const shortcutKey = e.key.toLowerCase();
-        if (shortcutKey in TOOL_SHORTCUTS_BY_KEY) {
-          const tool = TOOL_SHORTCUTS_BY_KEY[shortcutKey as keyof typeof TOOL_SHORTCUTS_BY_KEY];
+        const tool = getToolForShortcutKey(e.key);
+        if (tool) {
           useEditorStore.getState().setActiveTool(tool);
           return;
         }

--- a/src/app/useKeyboardShortcuts.ts
+++ b/src/app/useKeyboardShortcuts.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useProjectStore, useEditorStore } from '@/app/store';
-import type { EditorTool } from '@/app/store';
+import { TOOL_SHORTCUTS_BY_KEY } from '@/app/toolMetadata';
 
 export function useKeyboardShortcuts() {
   useEffect(() => {
@@ -60,19 +60,9 @@ export function useKeyboardShortcuts() {
 
       // Tool shortcuts (single key)
       if (!ctrl && !e.altKey) {
-        const toolMap: Record<string, EditorTool> = {
-          v: 'select',
-          h: 'pan',
-          c: 'column',
-          b: 'beam',
-          w: 'wall',
-          s: 'slab',
-          d: 'dimension',
-          t: 'annotation',
-        };
-
-        const tool = toolMap[e.key.toLowerCase()];
-        if (tool) {
+        const shortcutKey = e.key.toLowerCase();
+        if (shortcutKey in TOOL_SHORTCUTS_BY_KEY) {
+          const tool = TOOL_SHORTCUTS_BY_KEY[shortcutKey as keyof typeof TOOL_SHORTCUTS_BY_KEY];
           useEditorStore.getState().setActiveTool(tool);
           return;
         }

--- a/src/components/common/StatusBar.tsx
+++ b/src/components/common/StatusBar.tsx
@@ -1,8 +1,14 @@
 import { useEditorStore } from '@/app/store';
+import { getToolStatusLabel } from '@/app/toolMetadata';
 import { useI18n } from '@/i18n';
 
 export function StatusBar() {
-  const { cursorWorld, zoom, snapEnabled, selectedIds, activeStory, activeTool } = useEditorStore();
+  const cursorWorld = useEditorStore((s) => s.cursorWorld);
+  const zoom = useEditorStore((s) => s.zoom);
+  const snapEnabled = useEditorStore((s) => s.snapEnabled);
+  const selectedIds = useEditorStore((s) => s.selectedIds);
+  const activeStory = useEditorStore((s) => s.activeStory);
+  const activeTool = useEditorStore((s) => s.activeTool);
   const { t } = useI18n();
 
   return (
@@ -14,7 +20,7 @@ export function StatusBar() {
       </span>
       <span className="status-item">{t.statusZoom}: {(zoom * 1000).toFixed(0)}%</span>
       <span className="status-item">{t.statusSnap}: {snapEnabled ? t.statusOn : t.statusOff}</span>
-      <span className="status-item">{t.statusTool}: {activeTool}</span>
+      <span className="status-item">{t.statusTool}: {getToolStatusLabel(activeTool, t)}</span>
       <span className="status-item">{t.statusStory}: {activeStory ?? '---'}</span>
       <span className="status-item">{t.statusSelected}: {selectedIds.length}</span>
     </div>


### PR DESCRIPTION
## Summary
- Show localized tool names in the status bar instead of internal tool IDs
- Add shortcut hints for tools that already have keyboard shortcuts
- Move tool label/shortcut metadata into a small tested helper
- Narrow StatusBar store subscriptions to the values it renders

## Validation
- npm run lint
- npm run build
- npm test
