### PR TITLE
[codex] Accept space-separated coordinate input

### DIFF
--- a/src/features/editor2d/CoordinateInputDialog.tsx
+++ b/src/features/editor2d/CoordinateInputDialog.tsx
@@ -1,61 +1,11 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { useI18n } from '@/i18n';
 import type { Point2D } from '@/domain/geometry/types';
+import { parseCoordinate } from './coordinateInput';
 
 interface Props {
   lastPoint: Point2D | null;
   onSubmit: (pos: Point2D) => void;
-}
-
-/**
- * Parses coordinate input in three formats:
- * - "x,y"        -> absolute coordinate
- * - "@dx,dy"     -> relative to lastPoint
- * - "@dist<angle" -> polar relative to lastPoint (angle in degrees)
- */
-function parseCoordinate(input: string, lastPoint: Point2D | null): Point2D | null {
-  const trimmed = input.trim();
-  if (!trimmed) return null;
-
-  if (trimmed.startsWith('@')) {
-    const rest = trimmed.slice(1);
-
-    // Polar: @distance<angle
-    const polarMatch = rest.match(/^([+-]?\d+\.?\d*)\s*<\s*([+-]?\d+\.?\d*)$/);
-    if (polarMatch) {
-      const dist = parseFloat(polarMatch[1]);
-      const angleDeg = parseFloat(polarMatch[2]);
-      if (!Number.isFinite(dist) || !Number.isFinite(angleDeg)) return null;
-      const rad = (angleDeg * Math.PI) / 180;
-      const base = lastPoint ?? { x: 0, y: 0 };
-      return {
-        x: base.x + dist * Math.cos(rad),
-        y: base.y + dist * Math.sin(rad),
-      };
-    }
-
-    // Relative: @dx,dy
-    const parts = rest.split(',');
-    if (parts.length === 2) {
-      const dx = parseFloat(parts[0]);
-      const dy = parseFloat(parts[1]);
-      if (!Number.isFinite(dx) || !Number.isFinite(dy)) return null;
-      const base = lastPoint ?? { x: 0, y: 0 };
-      return { x: base.x + dx, y: base.y + dy };
-    }
-    return null;
-  }
-
-  // Absolute: x,y
-  const parts = trimmed.split(',');
-  if (parts.length === 2) {
-    const x = parseFloat(parts[0]);
-    const y = parseFloat(parts[1]);
-    if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
-    return { x, y };
-  }
-
-  return null;
 }
 
 export function CoordinateInputBar({ lastPoint, onSubmit }: Props) {
@@ -80,7 +30,7 @@ export function CoordinateInputBar({ lastPoint, onSubmit }: Props) {
     const handler = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement;
       if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.tagName === 'SELECT') return;
-      if (/^[0-9@\-.]$/.test(e.key)) {
+      if (/^[0-9@+\-.]$/.test(e.key)) {
         inputRef.current?.focus();
       }
     };

--- a/src/features/editor2d/__tests__/coordinateInput.test.ts
+++ b/src/features/editor2d/__tests__/coordinateInput.test.ts
@@ -5,6 +5,9 @@ describe('parseCoordinate', () => {
   it('parses absolute comma and space separated coordinates', () => {
     expect(parseCoordinate('1000,2000', null)).toEqual({ x: 1000, y: 2000 });
     expect(parseCoordinate('1000 2000', null)).toEqual({ x: 1000, y: 2000 });
+    expect(parseCoordinate('-1000 -2000', null)).toEqual({ x: -1000, y: -2000 });
+    expect(parseCoordinate('1.5 2.5', null)).toEqual({ x: 1.5, y: 2.5 });
+    expect(parseCoordinate('  1000   2000  ', null)).toEqual({ x: 1000, y: 2000 });
   });
 
   it('parses relative comma and space separated coordinates', () => {
@@ -22,5 +25,6 @@ describe('parseCoordinate', () => {
   it('rejects incomplete coordinate pairs', () => {
     expect(parseCoordinate('1000', null)).toBeNull();
     expect(parseCoordinate('@100 200 300', null)).toBeNull();
+    expect(parseCoordinate('abc def', null)).toBeNull();
   });
 });

--- a/src/features/editor2d/__tests__/coordinateInput.test.ts
+++ b/src/features/editor2d/__tests__/coordinateInput.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { parseCoordinate } from '../coordinateInput';
+
+describe('parseCoordinate', () => {
+  it('parses absolute comma and space separated coordinates', () => {
+    expect(parseCoordinate('1000,2000', null)).toEqual({ x: 1000, y: 2000 });
+    expect(parseCoordinate('1000 2000', null)).toEqual({ x: 1000, y: 2000 });
+  });
+
+  it('parses relative comma and space separated coordinates', () => {
+    const lastPoint = { x: 500, y: -200 };
+    expect(parseCoordinate('@100,300', lastPoint)).toEqual({ x: 600, y: 100 });
+    expect(parseCoordinate('@100 300', lastPoint)).toEqual({ x: 600, y: 100 });
+  });
+
+  it('keeps polar input support', () => {
+    const point = parseCoordinate('@100<90', { x: 10, y: 20 });
+    expect(point?.x).toBeCloseTo(10);
+    expect(point?.y).toBeCloseTo(120);
+  });
+
+  it('rejects incomplete coordinate pairs', () => {
+    expect(parseCoordinate('1000', null)).toBeNull();
+    expect(parseCoordinate('@100 200 300', null)).toBeNull();
+  });
+});

--- a/src/features/editor2d/coordinateInput.ts
+++ b/src/features/editor2d/coordinateInput.ts
@@ -10,6 +10,7 @@ export function parseCoordinate(input: string, lastPoint: Point2D | null): Point
   const trimmed = input.trim();
   if (!trimmed) return null;
 
+  // Commas take precedence; otherwise a coordinate pair may be separated by whitespace.
   const parsePair = (value: string): [number, number] | null => {
     const parts = value.includes(',') ? value.split(',') : value.trim().split(/\s+/);
     if (parts.length !== 2) return null;

--- a/src/features/editor2d/coordinateInput.ts
+++ b/src/features/editor2d/coordinateInput.ts
@@ -1,0 +1,57 @@
+import type { Point2D } from '@/domain/geometry/types';
+
+/**
+ * Parses coordinate input in three formats:
+ * - "x,y" or "x y"        -> absolute coordinate
+ * - "@dx,dy" or "@dx dy"  -> relative to lastPoint
+ * - "@dist<angle" -> polar relative to lastPoint (angle in degrees)
+ */
+export function parseCoordinate(input: string, lastPoint: Point2D | null): Point2D | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  const parsePair = (value: string): [number, number] | null => {
+    const parts = value.includes(',') ? value.split(',') : value.trim().split(/\s+/);
+    if (parts.length !== 2) return null;
+    const x = parseFloat(parts[0]);
+    const y = parseFloat(parts[1]);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+    return [x, y];
+  };
+
+  if (trimmed.startsWith('@')) {
+    const rest = trimmed.slice(1);
+
+    // Polar: @distance<angle
+    const polarMatch = rest.match(/^([+-]?\d+\.?\d*)\s*<\s*([+-]?\d+\.?\d*)$/);
+    if (polarMatch) {
+      const dist = parseFloat(polarMatch[1]);
+      const angleDeg = parseFloat(polarMatch[2]);
+      if (!Number.isFinite(dist) || !Number.isFinite(angleDeg)) return null;
+      const rad = (angleDeg * Math.PI) / 180;
+      const base = lastPoint ?? { x: 0, y: 0 };
+      return {
+        x: base.x + dist * Math.cos(rad),
+        y: base.y + dist * Math.sin(rad),
+      };
+    }
+
+    // Relative: @dx,dy or @dx dy
+    const pair = parsePair(rest);
+    if (pair) {
+      const [dx, dy] = pair;
+      const base = lastPoint ?? { x: 0, y: 0 };
+      return { x: base.x + dx, y: base.y + dy };
+    }
+    return null;
+  }
+
+  // Absolute: x,y or x y
+  const pair = parsePair(trimmed);
+  if (pair) {
+    const [x, y] = pair;
+    return { x, y };
+  }
+
+  return null;
+}

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -176,7 +176,7 @@ export const en: Translations = {
   transformArrayRowSpacing: 'Row Spacing',
   transformArrayColSpacing: 'Column Spacing',
 
-  coordInputPlaceholder: 'x,y or @dx,dy or @dist<angle',
+  coordInputPlaceholder: 'x,y / x y or @dx,dy / @dx dy or @dist<angle',
   coordInputLabel: 'Coordinate',
 
   zoomExtents: 'Zoom Extents',

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -176,7 +176,7 @@ export const ja: Translations = {
   transformArrayRowSpacing: '行間隔',
   transformArrayColSpacing: '列間隔',
 
-  coordInputPlaceholder: 'x,y または @dx,dy または @距離<角度',
+  coordInputPlaceholder: 'x,y / x y または @dx,dy / @dx dy または @距離<角度',
   coordInputLabel: '座標',
 
   zoomExtents: '全体表示',


### PR DESCRIPTION
## Summary
- Accept space-separated coordinate input such as `1000 2000` and `@500 0`
- Keep existing comma-separated and polar coordinate formats working
- Move coordinate parsing into a pure helper with unit tests
- Update placeholders in English and Japanese, and focus the input when typing a leading `+`

## Validation
- npm run lint
- npm run build
- npm test
