### PR TITLE
[codex] Cycle overlapping selection hits

### DIFF
--- a/src/features/editor2d/__tests__/selectionCycle.test.ts
+++ b/src/features/editor2d/__tests__/selectionCycle.test.ts
@@ -1,7 +1,15 @@
-import { describe, expect, it } from 'vitest';
-import { pickSelectionCandidate, uniqueCandidateIds } from '../selectionCycle';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getEventCandidateIds, pickSelectionCandidate, uniqueCandidateIds } from '../selectionCycle';
+
+const originalElementsFromPoint = document.elementsFromPoint;
 
 describe('selection cycling', () => {
+  afterEach(() => {
+    document.elementsFromPoint = originalElementsFromPoint;
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
   it('deduplicates candidates while preserving hit order', () => {
     expect(uniqueCandidateIds(['beam-1', 'wall-1', 'beam-1', null, 'dim-1'])).toEqual([
       'beam-1',
@@ -21,5 +29,24 @@ describe('selection cycling', () => {
 
   it('falls back to the top candidate when current selection is outside the hit stack', () => {
     expect(pickSelectionCandidate(['beam-1', 'wall-1'], ['col-1'])).toBe('beam-1');
+  });
+
+  it('collects candidate ids from the DOM hit stack and target fallback', () => {
+    const beam = document.createElement('div');
+    beam.dataset.id = 'beam-1';
+    const beamChild = document.createElement('span');
+    beam.appendChild(beamChild);
+    const wall = document.createElement('div');
+    wall.dataset.id = 'wall-1';
+    document.body.append(beam, wall);
+
+    document.elementsFromPoint = vi.fn(() => [beamChild, wall]) as typeof document.elementsFromPoint;
+
+    const event = { clientX: 10, clientY: 20, target: beamChild } as unknown as Parameters<
+      typeof getEventCandidateIds
+    >[0];
+
+    expect(getEventCandidateIds(event)).toEqual(['beam-1', 'wall-1']);
+    expect(document.elementsFromPoint).toHaveBeenCalledWith(10, 20);
   });
 });

--- a/src/features/editor2d/__tests__/selectionCycle.test.ts
+++ b/src/features/editor2d/__tests__/selectionCycle.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { pickSelectionCandidate, uniqueCandidateIds } from '../selectionCycle';
+
+describe('selection cycling', () => {
+  it('deduplicates candidates while preserving hit order', () => {
+    expect(uniqueCandidateIds(['beam-1', 'wall-1', 'beam-1', null, 'dim-1'])).toEqual([
+      'beam-1',
+      'wall-1',
+      'dim-1',
+    ]);
+  });
+
+  it('starts from the top candidate when nothing is selected', () => {
+    expect(pickSelectionCandidate(['beam-1', 'wall-1'], [])).toBe('beam-1');
+  });
+
+  it('cycles from the current selected candidate', () => {
+    expect(pickSelectionCandidate(['beam-1', 'wall-1', 'dim-1'], ['beam-1'])).toBe('wall-1');
+    expect(pickSelectionCandidate(['beam-1', 'wall-1', 'dim-1'], ['dim-1'])).toBe('beam-1');
+  });
+
+  it('falls back to the top candidate when current selection is outside the hit stack', () => {
+    expect(pickSelectionCandidate(['beam-1', 'wall-1'], ['col-1'])).toBe('beam-1');
+  });
+});

--- a/src/features/editor2d/selectionCycle.ts
+++ b/src/features/editor2d/selectionCycle.ts
@@ -1,0 +1,29 @@
+import type { MouseEvent as ReactMouseEvent } from 'react';
+
+export function uniqueCandidateIds(ids: Array<string | null | undefined>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const id of ids) {
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    result.push(id);
+  }
+  return result;
+}
+
+export function pickSelectionCandidate(candidateIds: string[], selectedIds: string[]): string | null {
+  if (candidateIds.length === 0) return null;
+  if (candidateIds.length === 1) return candidateIds[0];
+
+  const activeId = selectedIds.length === 1 ? selectedIds[0] : null;
+  const index = activeId ? candidateIds.indexOf(activeId) : -1;
+  if (index === -1) return candidateIds[0];
+  return candidateIds[(index + 1) % candidateIds.length];
+}
+
+export function getEventCandidateIds(e: ReactMouseEvent): string[] {
+  const fromPoint = document.elementsFromPoint?.(e.clientX, e.clientY) ?? [];
+  const ids = fromPoint.map((element) => element.closest('[data-id]')?.getAttribute('data-id'));
+  const fallback = (e.target as Element | null)?.closest?.('[data-id]')?.getAttribute('data-id');
+  return uniqueCandidateIds([...ids, fallback]);
+}

--- a/src/features/editor2d/useEditorInteraction.ts
+++ b/src/features/editor2d/useEditorInteraction.ts
@@ -11,6 +11,7 @@ import type { SnapResult } from '@/domain/geometry/snap';
 import { snapPointToGrid } from '@/domain/geometry/transform';
 import { constrainPointToAngle } from '@/domain/geometry/angleConstraint';
 import { getEntityBoundsList, selectByRectangle } from '@/domain/structural/editTransform';
+import { getEventCandidateIds, pickSelectionCandidate } from './selectionCycle';
 
 export interface DrawState {
   /** Points collected so far for multi-click tools */
@@ -52,6 +53,16 @@ function applyAngleConstraint(
   pos: Point2D,
 ): Point2D {
   return constrainPointToAngle(points[points.length - 1], pos);
+}
+
+function isSelectableId(id: string, layerLocked: Record<string, boolean>): boolean {
+  const data = useProjectStore.getState().data;
+  if (!data) return true;
+  const member = data.members.find((m) => m.id === id);
+  if (member) return !layerLocked[`member-${member.type}`];
+  if (data.annotations.some((a) => a.id === id)) return !layerLocked.annotation;
+  if (data.dimensions.some((d) => d.id === id)) return !layerLocked.dimension;
+  return true;
 }
 
 export function useEditorInteraction() {
@@ -296,23 +307,13 @@ export function useEditorInteraction() {
       const { activeTool, setSelectedIds, toggleSelection, layerLocked } = useEditorStore.getState();
 
       if (activeTool === 'select') {
-        const target = (e.target as SVGElement).closest('[data-id]');
-        if (!target) {
+        const candidateIds = getEventCandidateIds(e).filter((id) => isSelectableId(id, layerLocked));
+        const id = pickSelectionCandidate(candidateIds, useEditorStore.getState().selectedIds);
+        if (!id) {
           setSelectedIds([]);
           return;
         }
-        const id = target.getAttribute('data-id')!;
-
-        // Check if entity's layer is locked
         const data = useProjectStore.getState().data;
-        if (data) {
-          const member = data.members.find((m) => m.id === id);
-          if (member && layerLocked[`member-${member.type}`]) return;
-          const annotation = data.annotations.find((a) => a.id === id);
-          if (annotation && layerLocked['annotation']) return;
-          const dimension = data.dimensions.find((d) => d.id === id);
-          if (dimension && layerLocked['dimension']) return;
-        }
 
         // Group selection: if member belongs to a group, select all group members
         if (data) {

--- a/src/features/editor2d/useEditorInteraction.ts
+++ b/src/features/editor2d/useEditorInteraction.ts
@@ -308,7 +308,10 @@ export function useEditorInteraction() {
 
       if (activeTool === 'select') {
         const candidateIds = getEventCandidateIds(e).filter((id) => isSelectableId(id, layerLocked));
-        const id = pickSelectionCandidate(candidateIds, useEditorStore.getState().selectedIds);
+        const useCycle = !(e.shiftKey || e.ctrlKey || e.metaKey);
+        const id = useCycle
+          ? pickSelectionCandidate(candidateIds, useEditorStore.getState().selectedIds)
+          : candidateIds[0] ?? null;
         if (!id) {
           setSelectedIds([]);
           return;


### PR DESCRIPTION
## Summary
- Cycle through overlapping selectable entities at the click point
- Preserve existing group selection, locked-layer filtering, and modifier toggle behavior
- Add tested helpers for candidate de-duplication and cycle selection

## Validation
- npm run lint
- npm run build
- npm test
