### PR TITLE
[codex] Accept distance-only coordinate input

### DIFF
--- a/src/features/editor2d/CoordinateInputDialog.tsx
+++ b/src/features/editor2d/CoordinateInputDialog.tsx
@@ -5,10 +5,11 @@ import { parseCoordinate } from './coordinateInput';
 
 interface Props {
   lastPoint: Point2D | null;
+  previewPoint: Point2D | null;
   onSubmit: (pos: Point2D) => void;
 }
 
-export function CoordinateInputBar({ lastPoint, onSubmit }: Props) {
+export function CoordinateInputBar({ lastPoint, previewPoint, onSubmit }: Props) {
   const [value, setValue] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
   const { t } = useI18n();
@@ -16,13 +17,13 @@ export function CoordinateInputBar({ lastPoint, onSubmit }: Props) {
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
       e.preventDefault();
-      const pos = parseCoordinate(value, lastPoint);
+      const pos = parseCoordinate(value, lastPoint, previewPoint);
       if (pos) {
         onSubmit(pos);
         setValue('');
       }
     },
-    [value, lastPoint, onSubmit],
+    [value, lastPoint, previewPoint, onSubmit],
   );
 
   // Focus when a digit or @ is pressed and this bar is visible

--- a/src/features/editor2d/Editor2D.tsx
+++ b/src/features/editor2d/Editor2D.tsx
@@ -254,7 +254,7 @@ export function Editor2D() {
         </SvgCanvas>
       </div>
       {isDrawingTool && (
-        <CoordinateInputBar lastPoint={lastPoint} onSubmit={injectCoordinate} />
+        <CoordinateInputBar lastPoint={lastPoint} previewPoint={drawState.previewPos} onSubmit={injectCoordinate} />
       )}
     </div>
   );

--- a/src/features/editor2d/__tests__/coordinateInput.test.ts
+++ b/src/features/editor2d/__tests__/coordinateInput.test.ts
@@ -22,6 +22,16 @@ describe('parseCoordinate', () => {
     expect(point?.y).toBeCloseTo(120);
   });
 
+  it('uses distance-only input along the preview direction', () => {
+    const point = parseCoordinate('@500', { x: 100, y: 200 }, { x: 1100, y: 200 });
+    expect(point).toEqual({ x: 600, y: 200 });
+  });
+
+  it('rejects distance-only input without a usable direction', () => {
+    expect(parseCoordinate('@500', { x: 100, y: 200 }, null)).toBeNull();
+    expect(parseCoordinate('@500', { x: 100, y: 200 }, { x: 100, y: 200 })).toBeNull();
+  });
+
   it('rejects incomplete coordinate pairs', () => {
     expect(parseCoordinate('1000', null)).toBeNull();
     expect(parseCoordinate('@100 200 300', null)).toBeNull();

--- a/src/features/editor2d/__tests__/coordinateInput.test.ts
+++ b/src/features/editor2d/__tests__/coordinateInput.test.ts
@@ -25,6 +25,9 @@ describe('parseCoordinate', () => {
   it('uses distance-only input along the preview direction', () => {
     const point = parseCoordinate('@500', { x: 100, y: 200 }, { x: 1100, y: 200 });
     expect(point).toEqual({ x: 600, y: 200 });
+
+    const negativePoint = parseCoordinate('@-500', { x: 100, y: 200 }, { x: 1100, y: 200 });
+    expect(negativePoint).toEqual({ x: -400, y: 200 });
   });
 
   it('rejects distance-only input without a usable direction', () => {

--- a/src/features/editor2d/coordinateInput.ts
+++ b/src/features/editor2d/coordinateInput.ts
@@ -5,8 +5,13 @@ import type { Point2D } from '@/domain/geometry/types';
  * - "x,y" or "x y"        -> absolute coordinate
  * - "@dx,dy" or "@dx dy"  -> relative to lastPoint
  * - "@dist<angle" -> polar relative to lastPoint (angle in degrees)
+ * - "@dist" -> relative to lastPoint along the current preview direction
  */
-export function parseCoordinate(input: string, lastPoint: Point2D | null): Point2D | null {
+export function parseCoordinate(
+  input: string,
+  lastPoint: Point2D | null,
+  previewPoint: Point2D | null = null,
+): Point2D | null {
   const trimmed = input.trim();
   if (!trimmed) return null;
 
@@ -34,6 +39,20 @@ export function parseCoordinate(input: string, lastPoint: Point2D | null): Point
       return {
         x: base.x + dist * Math.cos(rad),
         y: base.y + dist * Math.sin(rad),
+      };
+    }
+
+    // Distance along current preview direction: @distance
+    const distanceMatch = rest.match(/^([+-]?\d+\.?\d*)$/);
+    if (distanceMatch && lastPoint && previewPoint) {
+      const dist = parseFloat(distanceMatch[1]);
+      const dx = previewPoint.x - lastPoint.x;
+      const dy = previewPoint.y - lastPoint.y;
+      const length = Math.hypot(dx, dy);
+      if (!Number.isFinite(dist) || length === 0) return null;
+      return {
+        x: lastPoint.x + (dx / length) * dist,
+        y: lastPoint.y + (dy / length) * dist,
       };
     }
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -176,7 +176,7 @@ export const en: Translations = {
   transformArrayRowSpacing: 'Row Spacing',
   transformArrayColSpacing: 'Column Spacing',
 
-  coordInputPlaceholder: 'x,y / x y, @dx,dy / @dx dy, @dist or @dist<angle',
+  coordInputPlaceholder: 'x,y | @dx,dy | @d | @d<angle',
   coordInputLabel: 'Coordinate',
 
   zoomExtents: 'Zoom Extents',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -176,7 +176,7 @@ export const en: Translations = {
   transformArrayRowSpacing: 'Row Spacing',
   transformArrayColSpacing: 'Column Spacing',
 
-  coordInputPlaceholder: 'x,y / x y or @dx,dy / @dx dy or @dist<angle',
+  coordInputPlaceholder: 'x,y / x y, @dx,dy / @dx dy, @dist or @dist<angle',
   coordInputLabel: 'Coordinate',
 
   zoomExtents: 'Zoom Extents',

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -176,7 +176,7 @@ export const ja: Translations = {
   transformArrayRowSpacing: '行間隔',
   transformArrayColSpacing: '列間隔',
 
-  coordInputPlaceholder: 'x,y / x y または @dx,dy / @dx dy または @距離<角度',
+  coordInputPlaceholder: 'x,y / x y、@dx,dy / @dx dy、@距離 または @距離<角度',
   coordInputLabel: '座標',
 
   zoomExtents: '全体表示',

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -176,7 +176,7 @@ export const ja: Translations = {
   transformArrayRowSpacing: '行間隔',
   transformArrayColSpacing: '列間隔',
 
-  coordInputPlaceholder: 'x,y / x y、@dx,dy / @dx dy、@距離 または @距離<角度',
+  coordInputPlaceholder: 'x,y | @dx,dy | @距離 | @距離<角度',
   coordInputLabel: '座標',
 
   zoomExtents: '全体表示',


### PR DESCRIPTION
## Summary
- Accept distance-only relative input such as `@500` while drawing
- Resolve the distance along the current preview direction from the last point
- Keep existing absolute, relative pair, and polar coordinate formats intact
- Update placeholders and coordinate parser tests

## Validation
- npm run lint
- npm run build
- npm test
