### PR TITLE
[codex] Add selection edit handles

### DIFF
--- a/src/features/editor2d/Editor2D.tsx
+++ b/src/features/editor2d/Editor2D.tsx
@@ -10,6 +10,7 @@ import { canCompleteDrawing, useEditorInteraction } from './useEditorInteraction
 import { CoordinateInputBar } from './CoordinateInputDialog';
 import { EditorControls2D } from './EditorControls2D';
 import { DrawingGuide } from './DrawingGuide';
+import { SelectionHandles } from './SelectionHandles';
 import { getAllEntityBounds, getSelectionBounds } from '@/domain/structural/editTransform';
 
 export function Editor2D() {
@@ -249,6 +250,7 @@ export function Editor2D() {
               </g>
             );
           })}
+          {activeTool === 'select' && <SelectionHandles />}
           <DrawPreview drawState={drawState} activeTool={activeTool} />
           {selectionRectOverlay}
         </SvgCanvas>

--- a/src/features/editor2d/SelectionHandles.tsx
+++ b/src/features/editor2d/SelectionHandles.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useEditorStore, useProjectStore } from '@/app/store';
-import { screenToWorld } from '@/domain/geometry/transform';
+import { screenToWorld, snapPointToGrid } from '@/domain/geometry/transform';
 import type { Point2D } from '@/domain/geometry/types';
 import type { Member } from '@/domain/structural/types';
 import { getSelectionHandles, type SelectionHandle } from './editableHandles';
@@ -18,6 +18,16 @@ function updateLinearMemberPoint(member: Exclude<Member, { type: 'slab' }>, kind
   return { end: { ...member.end, x: point.x, y: point.y } } as Partial<Member>;
 }
 
+function getHandleKey(handle: SelectionHandle): string {
+  return `${handle.kind}-${handle.id}-${'vertexIndex' in handle ? handle.vertexIndex : 'point'}`;
+}
+
+function snapDragPoint(point: Point2D): Point2D {
+  const { activeSnapModes, gridSpacing, snapEnabled } = useEditorStore.getState();
+  if (!snapEnabled || !activeSnapModes.includes('grid')) return point;
+  return snapPointToGrid(point, gridSpacing);
+}
+
 export function SelectionHandles() {
   const data = useProjectStore((s) => s.data);
   const updateMember = useProjectStore((s) => s.updateMember);
@@ -28,6 +38,8 @@ export function SelectionHandles() {
   const activeStory = useEditorStore((s) => s.activeStory);
   const zoom = useEditorStore((s) => s.zoom);
   const [dragging, setDragging] = useState<{ handle: SelectionHandle; svg: SVGSVGElement } | null>(null);
+  const [dragPreviewPoint, setDragPreviewPoint] = useState<Point2D | null>(null);
+  const dragPreviewPointRef = useRef<Point2D | null>(null);
 
   const handles = data ? getSelectionHandles(data, selectedIds, activeStory) : [];
   const radius = Math.max(35, 6 / zoom);
@@ -81,10 +93,20 @@ export function SelectionHandles() {
 
     const handleMove = (e: MouseEvent) => {
       const point = toWorld(e);
-      if (point) applyDrag(point);
+      if (!point) return;
+      const snapped = snapDragPoint(point);
+      dragPreviewPointRef.current = snapped;
+      setDragPreviewPoint(snapped);
     };
 
-    const handleUp = () => setDragging(null);
+    const handleUp = (e: MouseEvent) => {
+      const currentPoint = toWorld(e);
+      const point = dragPreviewPointRef.current && currentPoint ? snapDragPoint(currentPoint) : dragPreviewPointRef.current;
+      if (point) applyDrag(point);
+      dragPreviewPointRef.current = null;
+      setDragPreviewPoint(null);
+      setDragging(null);
+    };
 
     window.addEventListener('mousemove', handleMove);
     window.addEventListener('mouseup', handleUp);
@@ -98,26 +120,35 @@ export function SelectionHandles() {
 
   return (
     <g className="selection-handles">
-      {handles.map((handle) => (
-        <circle
-          key={`${handle.kind}-${handle.id}-${'vertexIndex' in handle ? handle.vertexIndex : 'point'}`}
-          cx={handle.point.x}
-          cy={handle.point.y}
-          r={radius}
-          fill="#fff"
-          stroke="var(--accent)"
-          strokeWidth={Math.max(12, 2 / zoom)}
-          vectorEffect="non-scaling-stroke"
-          style={{ cursor: 'move', pointerEvents: 'all' }}
-          onMouseDown={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            const svg = e.currentTarget.ownerSVGElement;
-            if (svg) setDragging({ handle, svg });
-          }}
-          onClick={(e) => e.stopPropagation()}
-        />
-      ))}
+      {handles.map((handle) => {
+        const key = getHandleKey(handle);
+        const isDraggingHandle = dragging && getHandleKey(dragging.handle) === key;
+        const point = isDraggingHandle && dragPreviewPoint ? dragPreviewPoint : handle.point;
+        return (
+          <circle
+            key={key}
+            cx={point.x}
+            cy={point.y}
+            r={radius}
+            fill="#fff"
+            stroke="var(--accent)"
+            strokeWidth={Math.max(12, 2 / zoom)}
+            vectorEffect="non-scaling-stroke"
+            style={{ cursor: 'move', pointerEvents: 'all' }}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              const svg = e.currentTarget.ownerSVGElement;
+              if (svg) {
+                dragPreviewPointRef.current = null;
+                setDragPreviewPoint(null);
+                setDragging({ handle, svg });
+              }
+            }}
+            onClick={(e) => e.stopPropagation()}
+          />
+        );
+      })}
     </g>
   );
 }

--- a/src/features/editor2d/SelectionHandles.tsx
+++ b/src/features/editor2d/SelectionHandles.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from 'react';
+import { useEditorStore, useProjectStore } from '@/app/store';
+import { screenToWorld } from '@/domain/geometry/transform';
+import type { Point2D } from '@/domain/geometry/types';
+import type { Member } from '@/domain/structural/types';
+import { getSelectionHandles, type SelectionHandle } from './editableHandles';
+
+function updateLinearMemberPoint(member: Exclude<Member, { type: 'slab' }>, kind: SelectionHandle['kind'], point: Point2D): Partial<Member> {
+  if (kind === 'member-point') {
+    return {
+      start: { ...member.start, x: point.x, y: point.y },
+      end: { ...member.end, x: point.x, y: point.y },
+    } as Partial<Member>;
+  }
+  if (kind === 'member-start') {
+    return { start: { ...member.start, x: point.x, y: point.y } } as Partial<Member>;
+  }
+  return { end: { ...member.end, x: point.x, y: point.y } } as Partial<Member>;
+}
+
+export function SelectionHandles() {
+  const data = useProjectStore((s) => s.data);
+  const updateMember = useProjectStore((s) => s.updateMember);
+  const updateSlabVertex = useProjectStore((s) => s.updateSlabVertex);
+  const updateDimension = useProjectStore((s) => s.updateDimension);
+  const updateAnnotation = useProjectStore((s) => s.updateAnnotation);
+  const selectedIds = useEditorStore((s) => s.selectedIds);
+  const activeStory = useEditorStore((s) => s.activeStory);
+  const zoom = useEditorStore((s) => s.zoom);
+  const [dragging, setDragging] = useState<{ handle: SelectionHandle; svg: SVGSVGElement } | null>(null);
+
+  const handles = data ? getSelectionHandles(data, selectedIds, activeStory) : [];
+  const radius = Math.max(35, 6 / zoom);
+
+  useEffect(() => {
+    if (!dragging) return;
+
+    const toWorld = (e: MouseEvent): Point2D | null => {
+      const svg = dragging.svg;
+      if (!svg) return null;
+      const rect = svg.getBoundingClientRect();
+      const pan = useEditorStore.getState().pan;
+      const currentZoom = useEditorStore.getState().zoom;
+      return screenToWorld({ x: e.clientX - rect.left, y: e.clientY - rect.top }, pan, currentZoom);
+    };
+
+    const applyDrag = (point: Point2D) => {
+      const project = useProjectStore.getState().data;
+      if (!project) return;
+      const handle = dragging.handle;
+      if (handle.kind === 'slab-vertex') {
+        updateSlabVertex(handle.id, handle.vertexIndex, point);
+        return;
+      }
+      if (handle.kind === 'dimension-start') {
+        updateDimension(handle.id, { start: point });
+        return;
+      }
+      if (handle.kind === 'dimension-end') {
+        updateDimension(handle.id, { end: point });
+        return;
+      }
+      if (handle.kind === 'annotation-point') {
+        updateAnnotation(handle.id, { x: point.x, y: point.y });
+        return;
+      }
+      if (handle.kind === 'annotation-vertex') {
+        const annotation = project.annotations.find((item) => item.id === handle.id);
+        if (!annotation?.points) return;
+        const points = annotation.points.map((item, index) => (index === handle.vertexIndex ? point : item));
+        updateAnnotation(handle.id, {
+          points,
+          ...(handle.vertexIndex === 0 ? { x: point.x, y: point.y } : {}),
+        });
+        return;
+      }
+      const member = project.members.find((item) => item.id === handle.id);
+      if (!member || member.type === 'slab') return;
+      updateMember(handle.id, updateLinearMemberPoint(member, handle.kind, point));
+    };
+
+    const handleMove = (e: MouseEvent) => {
+      const point = toWorld(e);
+      if (point) applyDrag(point);
+    };
+
+    const handleUp = () => setDragging(null);
+
+    window.addEventListener('mousemove', handleMove);
+    window.addEventListener('mouseup', handleUp);
+    return () => {
+      window.removeEventListener('mousemove', handleMove);
+      window.removeEventListener('mouseup', handleUp);
+    };
+  }, [dragging, updateAnnotation, updateDimension, updateMember, updateSlabVertex]);
+
+  if (!data || handles.length === 0) return null;
+
+  return (
+    <g className="selection-handles">
+      {handles.map((handle) => (
+        <circle
+          key={`${handle.kind}-${handle.id}-${'vertexIndex' in handle ? handle.vertexIndex : 'point'}`}
+          cx={handle.point.x}
+          cy={handle.point.y}
+          r={radius}
+          fill="#fff"
+          stroke="var(--accent)"
+          strokeWidth={Math.max(12, 2 / zoom)}
+          vectorEffect="non-scaling-stroke"
+          style={{ cursor: 'move', pointerEvents: 'all' }}
+          onMouseDown={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            const svg = e.currentTarget.ownerSVGElement;
+            if (svg) setDragging({ handle, svg });
+          }}
+          onClick={(e) => e.stopPropagation()}
+        />
+      ))}
+    </g>
+  );
+}

--- a/src/features/editor2d/__tests__/selectionHandles.test.ts
+++ b/src/features/editor2d/__tests__/selectionHandles.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import type { ProjectData } from '@/domain/structural/types';
+import { getSelectionHandles } from '../editableHandles';
+
+const baseProject: ProjectData = {
+  schemaVersion: '1.0',
+  project: { id: 'p1', name: 'Test', unit: 'mm' },
+  stories: [{ id: '1F', name: '1F', elevation: 0, height: 3000 }],
+  grids: [],
+  materials: [],
+  sections: [],
+  members: [
+    {
+      id: 'beam-1',
+      type: 'beam',
+      story: '1F',
+      sectionId: 's',
+      materialId: 'm',
+      start: { x: 0, y: 0, z: 3000 },
+      end: { x: 1000, y: 0, z: 3000 },
+    },
+    {
+      id: 'slab-1',
+      type: 'slab',
+      story: '1F',
+      sectionId: 's',
+      materialId: 'm',
+      polygon: [{ x: 0, y: 0 }, { x: 1000, y: 0 }, { x: 1000, y: 1000 }],
+      level: 3000,
+    },
+  ],
+  openings: [],
+  annotations: [{ id: 'note-1', type: 'text', story: '1F', x: 200, y: 300, text: 'A' }],
+  dimensions: [{ id: 'dim-1', story: '1F', start: { x: 0, y: 0 }, end: { x: 1000, y: 0 }, offset: -500 }],
+  sheets: [],
+  views: [],
+};
+
+describe('getSelectionHandles', () => {
+  it('returns endpoints for selected linear members and dimensions', () => {
+    const handles = getSelectionHandles(baseProject, ['beam-1', 'dim-1'], '1F');
+    expect(handles.map((handle) => handle.kind)).toEqual([
+      'member-start',
+      'member-end',
+      'dimension-start',
+      'dimension-end',
+    ]);
+  });
+
+  it('returns slab vertex and annotation point handles', () => {
+    const handles = getSelectionHandles(baseProject, ['slab-1', 'note-1'], '1F');
+    expect(handles.filter((handle) => handle.kind === 'slab-vertex')).toHaveLength(3);
+    expect(handles.some((handle) => handle.kind === 'annotation-point')).toBe(true);
+  });
+});

--- a/src/features/editor2d/editableHandles.ts
+++ b/src/features/editor2d/editableHandles.ts
@@ -29,6 +29,7 @@ export function getSelectionHandles(
       handles.push({ kind: 'member-point', id: member.id, point: { x: member.start.x, y: member.start.y } });
       continue;
     }
+    // TODO: Merge coincident endpoint handles so shared joints can be moved together.
     handles.push({ kind: 'member-start', id: member.id, point: { x: member.start.x, y: member.start.y } });
     handles.push({ kind: 'member-end', id: member.id, point: { x: member.end.x, y: member.end.y } });
   }

--- a/src/features/editor2d/editableHandles.ts
+++ b/src/features/editor2d/editableHandles.ts
@@ -1,0 +1,54 @@
+import type { Point2D } from '@/domain/geometry/types';
+import type { ProjectData } from '@/domain/structural/types';
+
+export type SelectionHandle =
+  | { kind: 'member-start' | 'member-end' | 'member-point'; id: string; point: Point2D }
+  | { kind: 'slab-vertex'; id: string; vertexIndex: number; point: Point2D }
+  | { kind: 'dimension-start' | 'dimension-end'; id: string; point: Point2D }
+  | { kind: 'annotation-point'; id: string; point: Point2D }
+  | { kind: 'annotation-vertex'; id: string; vertexIndex: number; point: Point2D };
+
+export function getSelectionHandles(
+  data: ProjectData,
+  selectedIds: string[],
+  activeStory: string | null,
+): SelectionHandle[] {
+  const selected = new Set(selectedIds);
+  const inStory = (story: string) => !activeStory || story === activeStory;
+  const handles: SelectionHandle[] = [];
+
+  for (const member of data.members) {
+    if (!selected.has(member.id) || !inStory(member.story)) continue;
+    if (member.type === 'slab') {
+      member.polygon.forEach((point, vertexIndex) => {
+        handles.push({ kind: 'slab-vertex', id: member.id, vertexIndex, point });
+      });
+      continue;
+    }
+    if (member.type === 'column') {
+      handles.push({ kind: 'member-point', id: member.id, point: { x: member.start.x, y: member.start.y } });
+      continue;
+    }
+    handles.push({ kind: 'member-start', id: member.id, point: { x: member.start.x, y: member.start.y } });
+    handles.push({ kind: 'member-end', id: member.id, point: { x: member.end.x, y: member.end.y } });
+  }
+
+  for (const dimension of data.dimensions) {
+    if (!selected.has(dimension.id) || !inStory(dimension.story)) continue;
+    handles.push({ kind: 'dimension-start', id: dimension.id, point: dimension.start });
+    handles.push({ kind: 'dimension-end', id: dimension.id, point: dimension.end });
+  }
+
+  for (const annotation of data.annotations) {
+    if (!selected.has(annotation.id) || !inStory(annotation.story)) continue;
+    if (annotation.type === 'spline' && annotation.points && annotation.points.length > 0) {
+      annotation.points.forEach((point, vertexIndex) => {
+        handles.push({ kind: 'annotation-vertex', id: annotation.id, vertexIndex, point });
+      });
+    } else {
+      handles.push({ kind: 'annotation-point', id: annotation.id, point: { x: annotation.x, y: annotation.y } });
+    }
+  }
+
+  return handles;
+}


### PR DESCRIPTION
## Summary
- Add editable grips for selected 2D entities
- Support dragging linear member endpoints, column points, slab vertices, dimension endpoints, annotation points, and spline vertices
- Add a pure handle extraction helper with unit tests

## Validation
- npm run lint
- npm run build
- npm test
