### PR TITLE
ヘッドレス CLI の追加と Python 移植のためのバイト一致対応

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,9 @@ jobs:
       - run: npm run audit
       - run: npm run build
       - run: npm run check:bundle
+      # The headless CLI is a shipped artifact (the Python port calls it to
+      # regenerate golden files), so build it and exercise the bundle.
+      - run: npm run smoke:cli
 
   e2e:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-cli
 dist-ssr
 coverage
 playwright-report

--- a/README.md
+++ b/README.md
@@ -84,8 +84,16 @@ node dist-cli/index.js export src/samples/sample-project.json --format svg --she
 node dist-cli/index.js export src/samples/sample-project.json --format dxf --story 1F -o out.dxf
 ```
 
-CLI エントリは [src/cli/index.ts](src/cli/index.ts)。`@/domain/**` と Node 標準モジュールのみに依存し、
-ブラウザ専用アダプタ(`pdfExport`、React UI、ストア)には依存しません。
+CLI エントリは [src/cli/index.ts](src/cli/index.ts)、実装は [src/cli/run.ts](src/cli/run.ts)。
+`@/domain/**` と Node 標準モジュールのみに依存し、ブラウザ専用アダプタ(`pdfExport`、React UI、ストア)には依存しません。
+
+終了コードは 0(成功)/ 1(実行時エラー)/ 2(引数エラー)。存在しない `--sheet` / `--story` を
+指定した場合は**出力ファイルを作らずに非ゼロ終了**します(タイプミスで一見正常な図面が
+下流パイプラインに流れ込むのを防ぐため)。
+
+```bash
+npm run smoke:cli   # ビルド + dist-cli の動作確認(正常系・異常系)
+```
 
 #### Python 移植(simple-cad-py)
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,33 @@ npm run build
 
 `dist/` に静的ファイルが生成されます。任意の Web サーバーや CDN から配信可能です。
 
+### ヘッドレス CLI(図面のコマンドライン出力)
+
+描画コア(`src/domain/`)はブラウザ非依存の純粋 TypeScript であり、Node CLI から直接利用できます:
+
+```bash
+npm run build:cli   # dist-cli/index.js を生成
+node dist-cli/index.js list src/samples/sample-project.json
+node dist-cli/index.js validate src/samples/sample-project.json
+node dist-cli/index.js export src/samples/sample-project.json --format svg --sheet S-001 -o out.svg
+node dist-cli/index.js export src/samples/sample-project.json --format dxf --story 1F -o out.dxf
+```
+
+CLI エントリは [src/cli/index.ts](src/cli/index.ts)。`@/domain/**` と Node 標準モジュールのみに依存し、
+ブラウザ専用アダプタ(`pdfExport`、React UI、ストア)には依存しません。
+
+#### Python 移植(simple-cad-py)
+
+構造計算書ツール等の Python パイプラインから図面出力するための移植パッケージが
+別フォルダ `simple-cad-py/` にあります(将来の独立リポジトリ化を想定)。
+同一のプロジェクト JSON(契約: [src/schemas/project.schema.json](src/schemas/project.schema.json))から
+**バイト単位で同一**の SVG / DXF を出力することをゴールデンテストで担保しています。
+
+- 正の実装(source of truth)は本リポジトリの `src/domain/`
+- 描画仕様を変更したら `npm run build:cli && node scripts/generate-golden.mjs <path-to-simple-cad-py>`
+  でゴールデンを再生成し、Python 側を追従させて `pytest` を通すこと
+- 計画・経緯は [docs/CLI分離作業計画.md](docs/CLI分離作業計画.md) を参照
+
 ### テスト
 
 ```bash

--- a/docs/CLI分離作業計画.md
+++ b/docs/CLI分離作業計画.md
@@ -55,6 +55,13 @@
   - `validate` : プロジェクトJSONの検証(既存 `domain/validation` を利用)
   - PDF はブラウザ依存(jspdf)のため CLI 対象外とし、SVG→PDF 変換は Python 側で担う
 - [x] `package.json` に `build:cli` スクリプト追加(esbuild + tsconfig paths でバンドル)
+- [x] コマンド実装を `src/cli/run.ts`(`process.exit` を持たない純関数 `runCli`)に分離し、
+  `src/cli/index.ts` はプロセスへの配線のみとする(単体テスト可能にするため)
+- [x] 存在しない `--sheet` / `--story` の指定を非ゼロ終了で拒否
+  (DXF は storyId で部材を絞り込むだけのため、未知IDでもグリッド・表題欄を含む
+  「一見正常な」ファイルが生成されてしまう。計算書パイプラインへの静かな混入を防ぐ)
+- [x] CLI の単体テスト(`src/cli/__tests__/run.test.ts`)とバンドル済み成果物の
+  スモークテスト(`npm run smoke:cli`)を追加し、CI(quality ジョブ)に組み込み
 - [x] 浮動小数点の移植性対応: `Math.hypot` → `Math.sqrt(dx*dx + dy*dy)` に置換
   (`memberShape.ts` / `eccentricity.ts`。JSとPythonで最終ビット単位の出力一致を保証するため。
   実用上の数値差は最終桁ulpレベルで図面には影響なし)
@@ -130,6 +137,7 @@ simple-cad-py/
 | リスク | 対応 |
 |---|---|
 | 描画ロジックの二重管理(TS/Python乖離) | ゴールデンテストをCI化できる構成にし、TS側変更時に検知 |
+| CLI の退行がCIで検知されない | quality ジョブに `npm run smoke:cli`(ビルド + 正常系/異常系スモーク)を追加済み |
 | JS/Python の数値文字列化の差 | `jsnum.py` に集約し単体テストで網羅。最終的にバイト一致で検証 |
 | PDF出力のブラウザ依存 | Python側は SVG→PDF 変換(cairosvg等の任意依存)で代替。未導入環境ではSVG/DXFのみ |
 | スキーマ進化への追従 | スキーマ変更をトリガーにゴールデン再生成+Python側更新の運用ルールを文書化 |

--- a/docs/CLI分離作業計画.md
+++ b/docs/CLI分離作業計画.md
@@ -1,0 +1,141 @@
+# CLI分離作業計画 — 図面描画コアの分離と Python CLI 化
+
+作成日: 2026-08-04
+対象リポジトリ: Simple-CAD (structural-web-cad v1.0.0)
+
+## 1. 背景と目的
+
+- 利用者は Python 製の構造計算ツール(構造計算書生成)を運用しており、本 Web CAD の図面描画機能を以下の用途で使いたい:
+  1. 構造計算書に挿入する「リアルな図面」の挿絵生成
+  2. 計算書とは独立した図面ファイル(SVG / DXF / PDF)の出力
+- そのために、Web UI から描画コアを分離し、**Python の CLI / ライブラリとして利用できる構成**にする。
+
+## 2. 事前調査の結論(CLI分離の有効性判断)
+
+**判断:有効。** 根拠:
+
+| 観点 | 調査結果 |
+|---|---|
+| ブラウザ依存 | `src/domain/`(約15,700行)にブラウザAPI依存ゼロ。唯一の例外は `pdfExport.ts`(jspdf + DOMParser、48行)のみ |
+| 描画の実体 | `exportSvg(projectData, sheetId) → SVG文字列`、`exportDxf(projectData, storyId) → DXF文字列` の**純粋関数** |
+| データ契約 | `src/schemas/project.schema.json`(JSON Schema)が既に存在し、Web版とCLI版の共通言語として使える |
+| 移植規模 | 描画に必要なコードは依存を辿って約1,700行(うち型定義620行)と小規模 |
+
+方式は「**B. Python移植**」を採用(Python計算書パイプラインとの直接統合が目的のため)。
+ただし TypeScript 側にも Node CLI を追加し、**同一JSONから同一出力が得られることを機械検証**する(二重管理リスクの対策)。
+
+## 3. 全体アーキテクチャ
+
+```
+┌─────────────────────────────┐      ┌──────────────────────────────┐
+│  Web版 (React UI)            │      │  Python構造計算ツール(既存)   │
+│    └─ src/domain/ (描画コア)  │      │    └─ simple_cad (本計画で新設) │
+└──────────┬──────────────────┘      └──────────┬───────────────────┘
+           │ 読み書き                            │ 読み書き
+           ▼                                    ▼
+     ┌───────────────────────────────────────────────┐
+     │   プロジェクトJSON (project.schema.json が契約)   │
+     └───────────────────────────────────────────────┘
+           ▲                                    ▲
+           │ Node CLI (検証用リファレンス)          │ Python CLI (本命)
+      simple-cad export ...              python -m simple_cad export ...
+```
+
+- **契約(source of truth)**: `project.schema.json` とサンプルプロジェクトJSON
+- **正の実装(reference)**: TypeScript `src/domain/`(Web版と共通)
+- **利用実装**: Python `simple_cad` パッケージ(TS版とゴールデンテストで同一性を担保)
+
+## 4. 作業フェーズ
+
+### フェーズ1: TypeScript側の整理(CLI利用部分の分離)
+
+- [x] `src/cli/index.ts` を新設 — Node から `domain/` を直接呼ぶ CLI
+  - `export --format svg|dxf --sheet <id> / --story <id>` : 図面出力
+  - `list` : シート / 階(story)の一覧表示
+  - `validate` : プロジェクトJSONの検証(既存 `domain/validation` を利用)
+  - PDF はブラウザ依存(jspdf)のため CLI 対象外とし、SVG→PDF 変換は Python 側で担う
+- [x] `package.json` に `build:cli` スクリプト追加(esbuild + tsconfig paths でバンドル)
+- [x] 浮動小数点の移植性対応: `Math.hypot` → `Math.sqrt(dx*dx + dy*dy)` に置換
+  (`memberShape.ts` / `eccentricity.ts`。JSとPythonで最終ビット単位の出力一致を保証するため。
+  実用上の数値差は最終桁ulpレベルで図面には影響なし)
+- [x] 既存テスト・型チェック(`npm run check` 相当)が通ることを確認
+
+### フェーズ2: Python パッケージの新設(独立フォルダ `simple-cad-py/`)
+
+Web CAD リポジトリとは**別フォルダ**(`/Users/mina25/simple-cad-py/`)に自己完結パッケージとして出力する。
+将来そのまま `git init` して独立リポジトリ化できる構成とする。
+
+```
+simple-cad-py/
+  pyproject.toml          # パッケージ定義(Python 3.9+、標準ライブラリのみで動作)
+  README.md               # 使い方・計算書ツールへの組込み例
+  simple_cad/
+    __init__.py           # 公開API: export_svg / export_dxf / load_project
+    __main__.py           # python -m simple_cad
+    cli.py                # argparse CLI(export / list / validate)
+    jsnum.py              # ★ JS互換の数値→文字列変換(出力一致の要)
+    geometry.py           # point.ts の移植
+    paper.py              # paper.ts の移植(用紙サイズ・縮尺・表題欄)
+    line_style.py         # lineStyle.ts の移植(線種→破線パターン)
+    eccentricity.py       # eccentricity.ts の移植(軸偏心)
+    member_shape.py       # memberShape.ts の移植(部材平面形状)
+    svg_export.py         # svgExport.ts の移植(371行)
+    dxf_export.py         # dxfExport.ts の移植(388行)
+    pdf_export.py         # SVG→PDF 変換(cairosvg があれば利用、任意依存)
+    schema/project.schema.json  # スキーマ同梱(TS側からコピー、真実はTS側)
+  tests/
+    data/                 # サンプルプロジェクトJSON(TS側からコピー)
+    golden/               # TS版CLIが生成したゴールデン出力(svg/dxf)
+    test_golden.py        # Python出力とのバイト一致検証(pytest)
+    test_units.py         # 単体テスト(数値フォーマット・形状計算など)
+```
+
+移植対象(合計 約1,000行 + 型):
+
+| TSソース | 行数 | 備考 |
+|---|---|---|
+| svgExport.ts | 371 | 文字列生成のみ。表題欄3種・ビューポート・寸法・注釈含む |
+| dxfExport.ts | 388 | DXF ASCII生成。検証warning部分はスキーマ検証で代替 |
+| memberShape.ts | 142 | 柱・梁・壁・スラブの平面ポリゴン |
+| eccentricity.ts | 102 | 軸偏心の解決 |
+| point.ts / paper.ts / lineStyle.ts | 106 | 幾何・用紙・線種ユーティリティ |
+
+### フェーズ3: 出力同一性の担保(ゴールデンテスト)
+
+- [x] Node CLI で `src/samples/sample-project.json` から SVG / DXF を生成 → `python/tests/golden/` に保存
+- [x] pytest で Python 版の出力と**バイト単位で比較**
+- [x] 技術的な要点(JS↔Python差異の吸収):
+  - 数値→文字列: ECMAScript `Number::toString`(最短往復表現)を `jsnum.py` で再現
+  - `toFixed(n)`: `decimal` モジュールで同等の丸めを実装
+  - `encodeURIComponent` / `JSON.stringify`: `urllib.parse.quote`(safeセット調整)+ 自前JSONシリアライザ(キー順・数値表現をJS互換に)
+  - 浮動小数点演算: 演算順序を完全に一致させる(IEEE754 doubleは両言語共通)
+
+### フェーズ4: ドキュメント整備
+
+- [x] リポジトリ README にアーキテクチャ(層構造と契約)を追記
+- [x] `python/README.md` に計算書ツールからの利用例を記載:
+  - ライブラリとして: `svg = export_svg(project, sheet_id)` → 計算書に埋め込み
+  - CLIとして: `python -m simple_cad export plan.json --format svg -o fig1.svg`
+- [x] スキーマ更新時の運用ルール(TS側が真実、Python側へコピー+ゴールデン再生成)を明記
+
+## 5. 完了条件
+
+1. `npm run build:cli` で Node CLI がビルドでき、`export` / `list` / `validate` が動作する
+2. `python -m simple_cad export` が SVG / DXF を出力できる(Python 3.9+、外部依存なし)
+3. サンプルプロジェクトで TS版とPython版の SVG / DXF 出力がバイト一致(pytest green)
+4. 既存 Web 版のテスト(`npm run test` ほか)がすべて通る
+
+## 6. リスクと対応
+
+| リスク | 対応 |
+|---|---|
+| 描画ロジックの二重管理(TS/Python乖離) | ゴールデンテストをCI化できる構成にし、TS側変更時に検知 |
+| JS/Python の数値文字列化の差 | `jsnum.py` に集約し単体テストで網羅。最終的にバイト一致で検証 |
+| PDF出力のブラウザ依存 | Python側は SVG→PDF 変換(cairosvg等の任意依存)で代替。未導入環境ではSVG/DXFのみ |
+| スキーマ進化への追従 | スキーマ変更をトリガーにゴールデン再生成+Python側更新の運用ルールを文書化 |
+
+## 7. スコープ外(今回はやらないこと)
+
+- 3Dビュー・IFC入出力・構造解析関連ロジックのPython移植(描画に不要)
+- DXF**読み込み**(import)のPython移植(必要になった時点で別途)
+- Web版UIの機能変更(`Math.hypot`置換以外、挙動に影響する変更はしない)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist', 'coverage', 'playwright-report', 'test-results']),
+  globalIgnores(['dist', 'dist-cli', 'coverage', 'playwright-report', 'test-results']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1754,16 +1754,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -2243,9 +2243,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2613,9 +2613,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true,
       "optionalDependencies": {
@@ -2948,9 +2948,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -3946,9 +3946,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -4175,9 +4175,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -4195,7 +4195,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4923,9 +4923,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build",
     "build:cli": "tsc -b && vite build --config vite.cli.config.ts",
     "cli": "node dist-cli/index.js",
+    "smoke:cli": "npm run build:cli && node scripts/cli-smoke.mjs",
     "typecheck": "tsc -b",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "build:cli": "tsc -b && vite build --config vite.cli.config.ts",
+    "cli": "node dist-cli/index.js",
     "typecheck": "tsc -b",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/scripts/cli-smoke.mjs
+++ b/scripts/cli-smoke.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Smoke test for the built headless CLI (dist-cli/index.js).
+ *
+ * Unit tests cover `runCli` directly; this checks the *bundled* artifact, which
+ * is what the Python port and downstream tooling actually invoke.
+ *
+ * Usage:
+ *   npm run build:cli
+ *   node scripts/cli-smoke.mjs
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const cli = resolve(repoRoot, 'dist-cli/index.js');
+const project = resolve(repoRoot, 'src/samples/sample-project.json');
+
+if (!existsSync(cli)) {
+  console.error('dist-cli/index.js not found — run "npm run build:cli" first.');
+  process.exit(1);
+}
+
+const workDir = mkdtempSync(join(tmpdir(), 'simple-cad-smoke-'));
+const failures = [];
+
+function run(args) {
+  const result = spawnSync('node', [cli, ...args], { encoding: 'utf8' });
+  return { code: result.status, out: result.stdout ?? '', err: result.stderr ?? '' };
+}
+
+function check(name, args, expect) {
+  const result = run(args);
+  const problem = expect(result);
+  if (problem) {
+    failures.push(`${name}: ${problem}\n  exit=${result.code}\n  stderr=${result.err.trim()}`);
+  } else {
+    console.log(`ok  ${name}`);
+  }
+}
+
+const expectOk = (contains) => (r) =>
+  r.code !== 0
+    ? `expected exit 0`
+    : contains && !r.out.includes(contains)
+      ? `stdout missing ${JSON.stringify(contains)}`
+      : null;
+
+check('list', ['list', project], expectOk('sheets:'));
+check('validate', ['validate', project], expectOk('validation OK'));
+check('export svg (default sheet)', ['export', project, '--format', 'svg'], expectOk('<svg'));
+check('export dxf (default story)', ['export', project, '--format', 'dxf'], expectOk('SECTION'));
+
+const svgOut = join(workDir, 'plan.svg');
+check('export svg to file', ['export', project, '--format', 'svg', '--sheet', 'S-001', '-o', svgOut], (r) =>
+  r.code !== 0 ? 'expected exit 0' : existsSync(svgOut) ? null : 'output file not written',
+);
+
+const dxfOut = join(workDir, 'plan.dxf');
+check('export dxf to file', ['export', project, '--format', 'dxf', '--story', '1F', '-o', dxfOut], (r) =>
+  r.code !== 0 ? 'expected exit 0' : existsSync(dxfOut) ? null : 'output file not written',
+);
+
+// Regression: an unknown id must fail loudly instead of emitting a
+// plausible-looking drawing built from grids and the title block alone.
+const badDxf = join(workDir, 'bad.dxf');
+check(
+  'unknown story fails without writing a file',
+  ['export', project, '--format', 'dxf', '--story', 'DOES-NOT-EXIST', '-o', badDxf],
+  (r) =>
+    r.code === 0
+      ? 'expected non-zero exit'
+      : !r.err.includes('unknown story')
+        ? 'stderr missing "unknown story"'
+        : existsSync(badDxf)
+          ? 'wrote an output file for an unknown story'
+          : null,
+);
+
+const badSvg = join(workDir, 'bad.svg');
+check(
+  'unknown sheet fails without writing a file',
+  ['export', project, '--format', 'svg', '--sheet', 'DOES-NOT-EXIST', '-o', badSvg],
+  (r) =>
+    r.code === 0
+      ? 'expected non-zero exit'
+      : !r.err.includes('unknown sheet')
+        ? 'stderr missing "unknown sheet"'
+        : r.err.includes('at ')
+          ? 'leaked a stack trace'
+          : existsSync(badSvg)
+            ? 'wrote an output file for an unknown sheet'
+            : null,
+);
+
+check('unsupported format exits 2', ['export', project, '--format', 'pdf'], (r) =>
+  r.code === 2 ? null : 'expected exit 2',
+);
+
+rmSync(workDir, { recursive: true, force: true });
+
+if (failures.length > 0) {
+  console.error(`\n${failures.length} smoke check(s) failed:\n${failures.join('\n')}`);
+  process.exit(1);
+}
+console.log('\nCLI smoke tests passed.');

--- a/scripts/generate-golden.mjs
+++ b/scripts/generate-golden.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/**
+ * Regenerate the golden SVG/DXF files consumed by the Python port's
+ * byte-parity tests (simple-cad-py/tests/golden).
+ *
+ * Usage:
+ *   npm run build:cli
+ *   node scripts/generate-golden.mjs [path-to-simple-cad-py]
+ *
+ * Default target: ../simple-cad-py (sibling checkout).
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const cli = resolve(repoRoot, 'dist-cli/index.js');
+const target = resolve(process.argv[2] ?? resolve(repoRoot, '../simple-cad-py'));
+
+if (!existsSync(cli)) {
+  console.error('dist-cli/index.js not found — run "npm run build:cli" first.');
+  process.exit(1);
+}
+if (!existsSync(target)) {
+  console.error(`target not found: ${target}`);
+  process.exit(1);
+}
+
+const goldenDir = resolve(target, 'tests/golden');
+const cases = [
+  // [project file, output prefix, format, id]
+  [resolve(repoRoot, 'src/samples/sample-project.json'), 'sample', 'svg', 'S-001'],
+  [resolve(repoRoot, 'src/samples/sample-project.json'), 'sample', 'svg', 'S-002'],
+  [resolve(repoRoot, 'src/samples/sample-project.json'), 'sample', 'dxf', '1F'],
+  [resolve(repoRoot, 'src/samples/sample-project.json'), 'sample', 'dxf', '2F'],
+  [resolve(target, 'tests/data/torture-project.json'), 'torture', 'svg', 'SHT-COMPACT'],
+  [resolve(target, 'tests/data/torture-project.json'), 'torture', 'svg', 'SHT-MIN'],
+  [resolve(target, 'tests/data/torture-project.json'), 'torture', 'svg', 'SHT-NOVIEW'],
+  [resolve(target, 'tests/data/torture-project.json'), 'torture', 'dxf', '1F'],
+  [resolve(target, 'tests/data/torture-project.json'), 'torture', 'dxf', '2F'],
+];
+
+for (const [project, prefix, format, id] of cases) {
+  const selector = format === 'svg' ? '--sheet' : '--story';
+  const out = resolve(goldenDir, `${prefix}-${id}.${format}`);
+  execFileSync('node', [cli, 'export', project, '--format', format, selector, id, '-o', out], {
+    stdio: ['ignore', 'inherit', 'inherit'],
+  });
+}
+console.log('golden files regenerated. Now run pytest in the Python repo.');

--- a/src/cli/__tests__/run.test.ts
+++ b/src/cli/__tests__/run.test.ts
@@ -1,0 +1,138 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import sampleProject from '@/samples/sample-project.json';
+import { runCli, type CliStreams } from '../run';
+
+let workDir: string;
+let projectPath: string;
+
+beforeAll(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'simple-cad-cli-'));
+  projectPath = join(workDir, 'project.json');
+  writeFileSync(projectPath, JSON.stringify(sampleProject), 'utf8');
+});
+
+afterAll(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+interface RunResult {
+  code: number;
+  out: string;
+  err: string;
+}
+
+function run(...argv: string[]): RunResult {
+  let out = '';
+  let err = '';
+  const streams: CliStreams = {
+    out: (text) => {
+      out += text;
+    },
+    err: (text) => {
+      err += text;
+    },
+  };
+  return { code: runCli(argv, streams), out, err };
+}
+
+describe('simple-cad CLI', () => {
+  it('lists sheets and stories', () => {
+    const result = run('list', projectPath);
+    expect(result.code).toBe(0);
+    expect(result.out).toContain('S-001');
+    expect(result.out).toContain('1F');
+  });
+
+  it('exports SVG for an explicit sheet and defaults to the first one', () => {
+    const explicit = run('export', projectPath, '--format', 'svg', '--sheet', 'S-002');
+    expect(explicit.code).toBe(0);
+    expect(explicit.out).toContain('<svg');
+
+    const defaulted = run('export', projectPath, '--format', 'svg');
+    expect(defaulted.code).toBe(0);
+    expect(defaulted.out).toBe(run('export', projectPath, '--format', 'svg', '--sheet', 'S-001').out);
+  });
+
+  it('exports DXF for an explicit story and defaults to the first one', () => {
+    const explicit = run('export', projectPath, '--format', 'dxf', '--story', '2F');
+    expect(explicit.code).toBe(0);
+    expect(explicit.out).toContain('SECTION');
+
+    const defaulted = run('export', projectPath, '--format', 'dxf');
+    expect(defaulted.code).toBe(0);
+    expect(defaulted.out).toBe(run('export', projectPath, '--format', 'dxf', '--story', '1F').out);
+  });
+
+  // A missing story used to fall through to exportDxfWithWarnings, which only
+  // filters members by story: the header, grids and layers still rendered, so a
+  // typo produced a plausible-looking file and exit code 0.
+  it('rejects an unknown story instead of writing a partial DXF', () => {
+    const outPath = join(workDir, 'unknown-story.dxf');
+    const result = run(
+      'export',
+      projectPath,
+      '--format',
+      'dxf',
+      '--story',
+      'DOES-NOT-EXIST',
+      '-o',
+      outPath,
+    );
+    expect(result.code).not.toBe(0);
+    expect(result.err).toContain('unknown story "DOES-NOT-EXIST"');
+    expect(result.err).toContain('1F');
+    expect(existsSync(outPath)).toBe(false);
+  });
+
+  it('rejects an unknown sheet with a plain message rather than an exception', () => {
+    const outPath = join(workDir, 'unknown-sheet.svg');
+    const result = run('export', projectPath, '--sheet', 'NOPE', '-o', outPath);
+    expect(result.code).not.toBe(0);
+    expect(result.err).toContain('simple-cad: unknown sheet "NOPE"');
+    expect(existsSync(outPath)).toBe(false);
+  });
+
+  it('writes to the requested output file on success', () => {
+    const outPath = join(workDir, 'nested', 'plan.svg');
+    const result = run('export', projectPath, '--format', 'svg', '-o', outPath);
+    expect(result.code).toBe(0);
+    expect(existsSync(outPath)).toBe(true);
+  });
+
+  it('validates a well-formed project', () => {
+    const result = run('validate', projectPath);
+    expect(result.code).toBe(0);
+    expect(result.out).toContain('validation OK');
+  });
+
+  it('rejects malformed input before touching the exporters', () => {
+    const brokenJson = join(workDir, 'broken.json');
+    writeFileSync(brokenJson, '{ not json', 'utf8');
+    expect(run('export', brokenJson).code).toBe(1);
+    expect(run('export', brokenJson).err).toContain('invalid JSON');
+
+    const notAProject = join(workDir, 'other.json');
+    writeFileSync(notAProject, '{"hello":"world"}', 'utf8');
+    expect(run('list', notAProject).err).toContain('not a Simple-CAD project');
+
+    expect(run('export', join(workDir, 'missing.json')).err).toContain('cannot read file');
+  });
+
+  it('reports usage errors with exit code 2', () => {
+    expect(run('export', projectPath, '--format', 'pdf').code).toBe(2);
+    expect(run('export', projectPath, '--nope').code).toBe(2);
+    expect(run('export', projectPath, '--sheet').err).toContain('missing value for --sheet');
+    expect(run('export').code).toBe(2);
+    expect(run('frobnicate').code).toBe(2);
+    expect(run().code).toBe(2);
+  });
+
+  it('prints usage on --help with exit code 0', () => {
+    const result = run('--help');
+    expect(result.code).toBe(0);
+    expect(result.out).toContain('simple-cad export');
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,187 +1,30 @@
+#!/usr/bin/env node
 /**
  * simple-cad CLI — headless drawing export over the browser-free domain core.
  *
- * This entry must only depend on `@/domain/**` (pure TypeScript) and Node
- * built-ins. Browser-only adapters (pdfExport, React UI, stores) are out of
- * bounds; SVG→PDF conversion is delegated to downstream tooling.
+ * This entry must only depend on `@/domain/**` (pure TypeScript, via ./run) and
+ * Node built-ins. Browser-only adapters (pdfExport, React UI, stores) are out
+ * of bounds; SVG→PDF conversion is delegated to downstream tooling.
  *
  * Usage:
  *   simple-cad list <project.json>
  *   simple-cad validate <project.json>
  *   simple-cad export <project.json> [--format svg|dxf] [--sheet ID] [--story ID] [-o FILE]
  */
-import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
 import process from 'node:process';
-import { exportSvg } from '@/domain/export/svgExport';
-import { exportDxfWithWarnings } from '@/domain/export/dxfExport';
-import { validateProject } from '@/domain/validation';
-import type { ProjectData } from '@/domain/structural/types';
+import { runCli } from './run';
 
-const USAGE = `simple-cad — headless drawing export for Simple-CAD projects
-
-Usage:
-  simple-cad list <project.json>
-      List sheets and stories in the project.
-
-  simple-cad validate <project.json>
-      Run the full validation pipeline. Exits non-zero on errors.
-
-  simple-cad export <project.json> [options]
-      Render a drawing.
-      --format svg|dxf   Output format (default: svg)
-      --sheet <id>       Sheet id for SVG export (default: first sheet)
-      --story <id>       Story id for DXF export (default: first story)
-      -o, --output <f>   Output file (default: stdout)
-`;
-
-function fail(message: string, code = 1): never {
-  process.stderr.write(`simple-cad: ${message}\n`);
-  process.exit(code);
+let exitCode: number;
+try {
+  exitCode = runCli(process.argv.slice(2), {
+    out: (text) => void process.stdout.write(text),
+    err: (text) => void process.stderr.write(text),
+  });
+} catch (error) {
+  // Unexpected failures are bugs, not user errors — keep the stack.
+  process.stderr.write(
+    `simple-cad: internal error\n${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`,
+  );
+  exitCode = 70; // EX_SOFTWARE
 }
-
-function loadProject(path: string): ProjectData {
-  let raw: string;
-  try {
-    raw = readFileSync(path, 'utf8');
-  } catch {
-    fail(`cannot read file: ${path}`);
-  }
-  try {
-    return JSON.parse(raw) as ProjectData;
-  } catch (error) {
-    fail(`invalid JSON in ${path}: ${error instanceof Error ? error.message : String(error)}`);
-  }
-}
-
-function writeOutput(content: string, outputPath: string | undefined): void {
-  if (!outputPath) {
-    process.stdout.write(content);
-    if (!content.endsWith('\n')) process.stdout.write('\n');
-    return;
-  }
-  const target = resolve(outputPath);
-  mkdirSync(dirname(target), { recursive: true });
-  writeFileSync(target, content, 'utf8');
-  process.stderr.write(`wrote ${target}\n`);
-}
-
-interface ExportOptions {
-  input: string;
-  format: 'svg' | 'dxf';
-  sheet?: string;
-  story?: string;
-  output?: string;
-}
-
-function parseExportArgs(args: string[]): ExportOptions {
-  const options: ExportOptions = { input: '', format: 'svg' };
-  const positional: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    const next = (): string => {
-      const value = args[++i];
-      if (value === undefined) fail(`missing value for ${arg}`, 2);
-      return value;
-    };
-    switch (arg) {
-      case '--format': {
-        const value = next();
-        if (value !== 'svg' && value !== 'dxf') {
-          fail(`unsupported format "${value}" (svg|dxf; for PDF convert the SVG downstream)`, 2);
-        }
-        options.format = value;
-        break;
-      }
-      case '--sheet':
-        options.sheet = next();
-        break;
-      case '--story':
-        options.story = next();
-        break;
-      case '-o':
-      case '--output':
-        options.output = next();
-        break;
-      default:
-        if (arg.startsWith('-')) fail(`unknown option ${arg}`, 2);
-        positional.push(arg);
-    }
-  }
-  if (positional.length !== 1) fail('export needs exactly one <project.json> argument', 2);
-  options.input = positional[0];
-  return options;
-}
-
-function commandList(args: string[]): void {
-  if (args.length !== 1) fail('list needs exactly one <project.json> argument', 2);
-  const data = loadProject(args[0]);
-  const lines: string[] = [];
-  lines.push(`project: ${data.project.name} (${data.project.id})`);
-  lines.push('sheets:');
-  for (const sheet of data.sheets) {
-    lines.push(`  ${sheet.id}\t${sheet.name}\t${sheet.paperSize}\t${sheet.scale}`);
-  }
-  lines.push('stories:');
-  for (const story of data.stories) {
-    lines.push(`  ${story.id}\t${story.name}\televation=${story.elevation}`);
-  }
-  process.stdout.write(lines.join('\n') + '\n');
-}
-
-function commandValidate(args: string[]): void {
-  if (args.length !== 1) fail('validate needs exactly one <project.json> argument', 2);
-  const data = loadProject(args[0]);
-  const result = validateProject(data);
-  for (const issue of result.errors) {
-    process.stderr.write(`[${issue.level}] ${issue.message}\n`);
-  }
-  if (!result.ok) fail('validation failed');
-  process.stdout.write('validation OK\n');
-}
-
-function commandExport(args: string[]): void {
-  const options = parseExportArgs(args);
-  const data = loadProject(options.input);
-
-  if (options.format === 'svg') {
-    const sheetId = options.sheet ?? data.sheets[0]?.id;
-    if (!sheetId) fail('project has no sheets; specify --sheet');
-    writeOutput(exportSvg(data, sheetId), options.output);
-    return;
-  }
-
-  const storyId = options.story ?? data.stories[0]?.id;
-  if (!storyId) fail('project has no stories; specify --story');
-  const { content, warnings } = exportDxfWithWarnings(data, storyId);
-  for (const warning of warnings) {
-    process.stderr.write(`warning: ${warning}\n`);
-  }
-  writeOutput(content, options.output);
-}
-
-function main(): void {
-  const [command, ...rest] = process.argv.slice(2);
-  switch (command) {
-    case 'list':
-      commandList(rest);
-      break;
-    case 'validate':
-      commandValidate(rest);
-      break;
-    case 'export':
-      commandExport(rest);
-      break;
-    case '--help':
-    case '-h':
-    case 'help':
-    case undefined:
-      process.stdout.write(USAGE);
-      if (command === undefined) process.exit(2);
-      break;
-    default:
-      fail(`unknown command "${command}"\n\n${USAGE}`, 2);
-  }
-}
-
-main();
+process.exit(exitCode);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,187 @@
+/**
+ * simple-cad CLI — headless drawing export over the browser-free domain core.
+ *
+ * This entry must only depend on `@/domain/**` (pure TypeScript) and Node
+ * built-ins. Browser-only adapters (pdfExport, React UI, stores) are out of
+ * bounds; SVG→PDF conversion is delegated to downstream tooling.
+ *
+ * Usage:
+ *   simple-cad list <project.json>
+ *   simple-cad validate <project.json>
+ *   simple-cad export <project.json> [--format svg|dxf] [--sheet ID] [--story ID] [-o FILE]
+ */
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import process from 'node:process';
+import { exportSvg } from '@/domain/export/svgExport';
+import { exportDxfWithWarnings } from '@/domain/export/dxfExport';
+import { validateProject } from '@/domain/validation';
+import type { ProjectData } from '@/domain/structural/types';
+
+const USAGE = `simple-cad — headless drawing export for Simple-CAD projects
+
+Usage:
+  simple-cad list <project.json>
+      List sheets and stories in the project.
+
+  simple-cad validate <project.json>
+      Run the full validation pipeline. Exits non-zero on errors.
+
+  simple-cad export <project.json> [options]
+      Render a drawing.
+      --format svg|dxf   Output format (default: svg)
+      --sheet <id>       Sheet id for SVG export (default: first sheet)
+      --story <id>       Story id for DXF export (default: first story)
+      -o, --output <f>   Output file (default: stdout)
+`;
+
+function fail(message: string, code = 1): never {
+  process.stderr.write(`simple-cad: ${message}\n`);
+  process.exit(code);
+}
+
+function loadProject(path: string): ProjectData {
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch {
+    fail(`cannot read file: ${path}`);
+  }
+  try {
+    return JSON.parse(raw) as ProjectData;
+  } catch (error) {
+    fail(`invalid JSON in ${path}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function writeOutput(content: string, outputPath: string | undefined): void {
+  if (!outputPath) {
+    process.stdout.write(content);
+    if (!content.endsWith('\n')) process.stdout.write('\n');
+    return;
+  }
+  const target = resolve(outputPath);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, content, 'utf8');
+  process.stderr.write(`wrote ${target}\n`);
+}
+
+interface ExportOptions {
+  input: string;
+  format: 'svg' | 'dxf';
+  sheet?: string;
+  story?: string;
+  output?: string;
+}
+
+function parseExportArgs(args: string[]): ExportOptions {
+  const options: ExportOptions = { input: '', format: 'svg' };
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const next = (): string => {
+      const value = args[++i];
+      if (value === undefined) fail(`missing value for ${arg}`, 2);
+      return value;
+    };
+    switch (arg) {
+      case '--format': {
+        const value = next();
+        if (value !== 'svg' && value !== 'dxf') {
+          fail(`unsupported format "${value}" (svg|dxf; for PDF convert the SVG downstream)`, 2);
+        }
+        options.format = value;
+        break;
+      }
+      case '--sheet':
+        options.sheet = next();
+        break;
+      case '--story':
+        options.story = next();
+        break;
+      case '-o':
+      case '--output':
+        options.output = next();
+        break;
+      default:
+        if (arg.startsWith('-')) fail(`unknown option ${arg}`, 2);
+        positional.push(arg);
+    }
+  }
+  if (positional.length !== 1) fail('export needs exactly one <project.json> argument', 2);
+  options.input = positional[0];
+  return options;
+}
+
+function commandList(args: string[]): void {
+  if (args.length !== 1) fail('list needs exactly one <project.json> argument', 2);
+  const data = loadProject(args[0]);
+  const lines: string[] = [];
+  lines.push(`project: ${data.project.name} (${data.project.id})`);
+  lines.push('sheets:');
+  for (const sheet of data.sheets) {
+    lines.push(`  ${sheet.id}\t${sheet.name}\t${sheet.paperSize}\t${sheet.scale}`);
+  }
+  lines.push('stories:');
+  for (const story of data.stories) {
+    lines.push(`  ${story.id}\t${story.name}\televation=${story.elevation}`);
+  }
+  process.stdout.write(lines.join('\n') + '\n');
+}
+
+function commandValidate(args: string[]): void {
+  if (args.length !== 1) fail('validate needs exactly one <project.json> argument', 2);
+  const data = loadProject(args[0]);
+  const result = validateProject(data);
+  for (const issue of result.errors) {
+    process.stderr.write(`[${issue.level}] ${issue.message}\n`);
+  }
+  if (!result.ok) fail('validation failed');
+  process.stdout.write('validation OK\n');
+}
+
+function commandExport(args: string[]): void {
+  const options = parseExportArgs(args);
+  const data = loadProject(options.input);
+
+  if (options.format === 'svg') {
+    const sheetId = options.sheet ?? data.sheets[0]?.id;
+    if (!sheetId) fail('project has no sheets; specify --sheet');
+    writeOutput(exportSvg(data, sheetId), options.output);
+    return;
+  }
+
+  const storyId = options.story ?? data.stories[0]?.id;
+  if (!storyId) fail('project has no stories; specify --story');
+  const { content, warnings } = exportDxfWithWarnings(data, storyId);
+  for (const warning of warnings) {
+    process.stderr.write(`warning: ${warning}\n`);
+  }
+  writeOutput(content, options.output);
+}
+
+function main(): void {
+  const [command, ...rest] = process.argv.slice(2);
+  switch (command) {
+    case 'list':
+      commandList(rest);
+      break;
+    case 'validate':
+      commandValidate(rest);
+      break;
+    case 'export':
+      commandExport(rest);
+      break;
+    case '--help':
+    case '-h':
+    case 'help':
+    case undefined:
+      process.stdout.write(USAGE);
+      if (command === undefined) process.exit(2);
+      break;
+    default:
+      fail(`unknown command "${command}"\n\n${USAGE}`, 2);
+  }
+}
+
+main();

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -1,0 +1,251 @@
+/**
+ * simple-cad CLI implementation.
+ *
+ * Kept free of `process.exit` and of the ambient streams so every command can
+ * be exercised from unit tests; `src/cli/index.ts` wires this to the real
+ * process. Like that entry point, this module must only depend on
+ * `@/domain/**` (pure TypeScript) and Node built-ins.
+ */
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { exportSvg } from '@/domain/export/svgExport';
+import { exportDxfWithWarnings } from '@/domain/export/dxfExport';
+import { validateProject } from '@/domain/validation';
+import type { ProjectData } from '@/domain/structural/types';
+
+export const USAGE = `simple-cad — headless drawing export for Simple-CAD projects
+
+Usage:
+  simple-cad list <project.json>
+      List sheets and stories in the project.
+
+  simple-cad validate <project.json>
+      Run the full validation pipeline. Exits non-zero on errors.
+
+  simple-cad export <project.json> [options]
+      Render a drawing.
+      --format svg|dxf   Output format (default: svg)
+      --sheet <id>       Sheet id for SVG export (default: first sheet)
+      --story <id>       Story id for DXF export (default: first story)
+      -o, --output <f>   Output file (default: stdout)
+`;
+
+/** Streams the CLI writes to; injected so tests can capture output. */
+export interface CliStreams {
+  out: (text: string) => void;
+  err: (text: string) => void;
+}
+
+/** A message meant for the user, with the exit code the process should use. */
+export class CliError extends Error {
+  readonly exitCode: number;
+
+  constructor(message: string, exitCode = 1) {
+    super(message);
+    this.name = 'CliError';
+    this.exitCode = exitCode;
+  }
+}
+
+function fail(message: string, code = 1): never {
+  throw new CliError(message, code);
+}
+
+function loadProject(path: string): ProjectData {
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch {
+    fail(`cannot read file: ${path}`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    fail(`invalid JSON in ${path}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  // Only the shape the commands below index into is checked here; run
+  // `simple-cad validate` for the full schema + semantic pipeline.
+  const candidate = parsed as Partial<ProjectData> | null;
+  if (
+    typeof candidate !== 'object' ||
+    candidate === null ||
+    !Array.isArray(candidate.sheets) ||
+    !Array.isArray(candidate.stories)
+  ) {
+    fail(`${path} is not a Simple-CAD project (expected "sheets" and "stories" arrays)`);
+  }
+  return candidate as ProjectData;
+}
+
+/**
+ * Resolve the sheet/story to render. An id the project does not contain is a
+ * hard error: exporting it would otherwise emit a plausible-looking drawing
+ * (frame, grids and title block survive the per-story filtering) from a typo.
+ */
+function resolveTargetId(
+  label: 'sheet' | 'story',
+  requested: string | undefined,
+  available: string[],
+): string {
+  if (available.length === 0) {
+    fail(`project has no ${label}s`);
+  }
+  if (requested === undefined) {
+    return available[0];
+  }
+  if (!available.includes(requested)) {
+    fail(`unknown ${label} "${requested}" (available: ${available.join(', ')})`);
+  }
+  return requested;
+}
+
+function writeOutput(content: string, outputPath: string | undefined, streams: CliStreams): void {
+  if (!outputPath) {
+    streams.out(content);
+    if (!content.endsWith('\n')) streams.out('\n');
+    return;
+  }
+  const target = resolve(outputPath);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, content, 'utf8');
+  streams.err(`wrote ${target}\n`);
+}
+
+interface ExportOptions {
+  input: string;
+  format: 'svg' | 'dxf';
+  sheet?: string;
+  story?: string;
+  output?: string;
+}
+
+function parseExportArgs(args: string[]): ExportOptions {
+  const options: ExportOptions = { input: '', format: 'svg' };
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const next = (): string => {
+      const value = args[++i];
+      if (value === undefined) fail(`missing value for ${arg}`, 2);
+      return value;
+    };
+    switch (arg) {
+      case '--format': {
+        const value = next();
+        if (value !== 'svg' && value !== 'dxf') {
+          fail(`unsupported format "${value}" (svg|dxf; for PDF convert the SVG downstream)`, 2);
+        }
+        options.format = value;
+        break;
+      }
+      case '--sheet':
+        options.sheet = next();
+        break;
+      case '--story':
+        options.story = next();
+        break;
+      case '-o':
+      case '--output':
+        options.output = next();
+        break;
+      default:
+        if (arg.startsWith('-')) fail(`unknown option ${arg}`, 2);
+        positional.push(arg);
+    }
+  }
+  if (positional.length !== 1) fail('export needs exactly one <project.json> argument', 2);
+  options.input = positional[0];
+  return options;
+}
+
+function commandList(args: string[], streams: CliStreams): void {
+  if (args.length !== 1) fail('list needs exactly one <project.json> argument', 2);
+  const data = loadProject(args[0]);
+  const lines: string[] = [];
+  lines.push(`project: ${data.project.name} (${data.project.id})`);
+  lines.push('sheets:');
+  for (const sheet of data.sheets) {
+    lines.push(`  ${sheet.id}\t${sheet.name}\t${sheet.paperSize}\t${sheet.scale}`);
+  }
+  lines.push('stories:');
+  for (const story of data.stories) {
+    lines.push(`  ${story.id}\t${story.name}\televation=${story.elevation}`);
+  }
+  streams.out(lines.join('\n') + '\n');
+}
+
+function commandValidate(args: string[], streams: CliStreams): void {
+  if (args.length !== 1) fail('validate needs exactly one <project.json> argument', 2);
+  const data = loadProject(args[0]);
+  const result = validateProject(data);
+  for (const issue of result.errors) {
+    streams.err(`[${issue.level}] ${issue.message}\n`);
+  }
+  if (!result.ok) fail('validation failed');
+  streams.out('validation OK\n');
+}
+
+function commandExport(args: string[], streams: CliStreams): void {
+  const options = parseExportArgs(args);
+  const data = loadProject(options.input);
+
+  if (options.format === 'svg') {
+    const sheetId = resolveTargetId(
+      'sheet',
+      options.sheet,
+      data.sheets.map((sheet) => sheet.id),
+    );
+    writeOutput(exportSvg(data, sheetId), options.output, streams);
+    return;
+  }
+
+  const storyId = resolveTargetId(
+    'story',
+    options.story,
+    data.stories.map((story) => story.id),
+  );
+  const { content, warnings } = exportDxfWithWarnings(data, storyId);
+  for (const warning of warnings) {
+    streams.err(`warning: ${warning}\n`);
+  }
+  writeOutput(content, options.output, streams);
+}
+
+/**
+ * Run one CLI invocation and return the process exit code. Only `CliError` is
+ * translated into a message; anything else is a bug and is left to the caller
+ * so the stack survives.
+ */
+export function runCli(argv: string[], streams: CliStreams): number {
+  const [command, ...rest] = argv;
+  try {
+    switch (command) {
+      case 'list':
+        commandList(rest, streams);
+        return 0;
+      case 'validate':
+        commandValidate(rest, streams);
+        return 0;
+      case 'export':
+        commandExport(rest, streams);
+        return 0;
+      case '--help':
+      case '-h':
+      case 'help':
+        streams.out(USAGE);
+        return 0;
+      case undefined:
+        streams.out(USAGE);
+        return 2;
+      default:
+        fail(`unknown command "${command}"\n\n${USAGE}`, 2);
+    }
+  } catch (error) {
+    if (error instanceof CliError) {
+      streams.err(`simple-cad: ${error.message}\n`);
+      return error.exitCode;
+    }
+    throw error;
+  }
+}

--- a/src/domain/structural/eccentricity.ts
+++ b/src/domain/structural/eccentricity.ts
@@ -70,7 +70,9 @@ export function linearAxisOffsetToWorld(
   if (isZero(offset)) return ZERO;
   const ax = end.x - start.x;
   const ay = end.y - start.y;
-  const len = Math.hypot(ax, ay);
+  // sqrt(ax²+ay²) instead of Math.hypot: identical IEEE754 result across
+  // languages, so ports (e.g. the Python CLI renderer) match bit-for-bit.
+  const len = Math.sqrt(ax * ax + ay * ay);
   if (len === 0) {
     // Degenerate plan direction: treat like a column (dx→x, dy→y).
     return { x: offset.dx, y: offset.dy, z: 0 };

--- a/src/domain/structural/memberShape.ts
+++ b/src/domain/structural/memberShape.ts
@@ -95,7 +95,9 @@ export function buildLinearMemberPolygon(
 ): Point2D[] | null {
   const dx = end.x - start.x;
   const dy = end.y - start.y;
-  const length = Math.hypot(dx, dy);
+  // sqrt(dx²+dy²) instead of Math.hypot: identical IEEE754 result across
+  // languages, so ports (e.g. the Python CLI renderer) match bit-for-bit.
+  const length = Math.sqrt(dx * dx + dy * dy);
   if (length === 0) return null;
 
   const normal = {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -30,5 +30,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/cli"]
 }

--- a/tsconfig.cli.json
+++ b/tsconfig.cli.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.cli.tsbuildinfo",
     "target": "ES2023",
     "lib": ["ES2023"],
     "module": "ESNext",
@@ -20,7 +20,13 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+
+    /* Path aliases (same as tsconfig.app.json) */
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
-  "include": ["vite.config.ts", "vite.cli.config.ts"]
+  "include": ["src/cli"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.cli.json" }
   ]
 }

--- a/vite.cli.config.ts
+++ b/vite.cli.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vite';
+import path from 'path';
+
+// Node CLI build: bundles src/cli + the pure domain core (and ajv) into a
+// single self-contained ESM file. No browser APIs may enter this graph.
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  ssr: {
+    noExternal: true,
+  },
+  build: {
+    ssr: 'src/cli/index.ts',
+    outDir: 'dist-cli',
+    target: 'node18',
+    sourcemap: false,
+    emptyOutDir: true,
+  },
+})


### PR DESCRIPTION
## 概要

`src/domain/` の描画コアはすでにブラウザ非依存の純粋 TypeScript なので、React アプリを介さずに図面を出力できる **Node CLI** を追加しました。

あわせて、この CLI を**リファレンス実装**として、Python 製の構造計算書ツールから図面を生成できるようにするための対応を入れています(Python パッケージ本体は別リポジトリ `simple-cad-py`。本 PR には含まれません)。

## 変更内容

### 1. ヘッドレス CLI

- [`src/cli/index.ts`](src/cli/index.ts) — `list` / `validate` / `export`(svg|dxf)
  - 依存は `@/domain/**` と Node 標準モジュールのみ。ブラウザ専用の `pdfExport`(jspdf/DOMParser)・React UI・ストアには一切依存しません
- `vite.cli.config.ts` + `tsconfig.cli.json` — node18 向けにバンドル
  - アプリ側 `tsconfig.app.json` から `src/cli` を除外し、DOM 型のコードと Node 型のコードを分離しています

```bash
npm run build:cli
node dist-cli/index.js list src/samples/sample-project.json
node dist-cli/index.js export src/samples/sample-project.json --format svg --sheet S-001 -o out.svg
node dist-cli/index.js export src/samples/sample-project.json --format dxf --story 1F -o out.dxf
```

### 2. `Math.hypot` → `Math.sqrt(dx*dx + dy*dy)` への置換

`memberShape.ts` / `eccentricity.ts` の 2 箇所。**挙動を変えるための変更ではなく、他言語への移植で結果をビット単位で再現可能にするため**です。

`Math.hypot` は仕様上オーバーフロー回避のための追加処理が許容されており、処理系によって余分な精度を持ちうるため、他言語で同一結果を再現できません。素朴な `sqrt` 形式なら IEEE754 の範囲で完全に一致します。ここで扱う座標は mm 単位でオーバーフロー域から遠く、置換によるリスクはありません。

### 3. ゴールデン生成スクリプト

- [`scripts/generate-golden.mjs`](scripts/generate-golden.mjs) — Python 側がバイト一致を検証するための SVG/DXF を一括再生成

### 4. ドキュメント

- README にヘッドレス CLI の使い方と Python 移植との関係・運用ルールを追記
- [`docs/CLI分離作業計画.md`](docs/CLI分離作業計画.md) — 分離の妥当性判断、アーキテクチャ、作業計画

## 検証

- `npm run lint` / `npm run typecheck` — 通過
- `npm run test` — **345 件すべて通過**(既存テストへの影響なし)
- `npm run build` / `npm run check:bundle` — 通過(バンドルバジェット内)
- CLI 実動作:`list` / `validate` / `export --format svg|dxf` を sample-project.json で確認
- Python 移植版との**バイト一致を確認済み**(SVG 5 種 / DXF 4 種。回転柱・偏心・破線・スプライン・複数行日本語注釈・ビューポート・XML 特殊文字を含む網羅ケース)

## 補足:Python 移植との運用

- **正(source of truth)は本リポジトリの `src/domain/`** です
- 描画仕様を変更した際は `npm run build:cli && node scripts/generate-golden.mjs <path-to-simple-cad-py>` でゴールデンを再生成し、Python 側を追従させる運用とします(乖離を機械的に検知できます)

🤖 Generated with [Claude Code](https://claude.com/claude-code)